### PR TITLE
Fixes/improvements to glbdump

### DIFF
--- a/modules/gltf/.bin/glbdump.js
+++ b/modules/gltf/.bin/glbdump.js
@@ -1,5 +1,0 @@
-#!/usr/bin/env node
-
-/* global console, process */
-/* eslint-disable no-console */
-require('../dist/scripts/glbdump');

--- a/modules/gltf/bin/glbdump.js
+++ b/modules/gltf/bin/glbdump.js
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+
+/* eslint-disable no-console */
+require('@loaders.gl/gltf/dist/scripts/glbdump');

--- a/modules/gltf/package.json
+++ b/modules/gltf/package.json
@@ -25,18 +25,18 @@
   "files": [
     "src",
     "dist",
-    ".bin",
     "README.md"
   ],
   "bin": {
-    "glbdump": "./.bin/glbdump"
+    "glbdump": "./bin/glbdump.js"
   },
   "scripts": {
     "clean": "rm -fr dist && mkdir -p dist",
-    "build": "npm run clean && npm run build-es6 && npm run build-esm && npm run build-es5",
+    "build": "npm run clean && npm run build-es6 && npm run build-esm && npm run build-es5 && npm run build-bin",
     "build-es6": "BABEL_ENV=es6 babel src --config-file ../../babel.config.js --out-dir dist/es6 --source-maps --ignore 'node_modules/'",
     "build-esm": "BABEL_ENV=esm babel src --config-file ../../babel.config.js --out-dir dist/esm --source-maps --ignore 'node_modules/'",
-    "build-es5": "BABEL_ENV=es5 babel src --config-file ../../babel.config.js --out-dir dist/es5 --source-maps --ignore 'node_modules/'"
+    "build-es5": "BABEL_ENV=es5 babel src --config-file ../../babel.config.js --out-dir dist/es5 --source-maps --ignore 'node_modules/'",
+    "build-bin": "BABEL_ENV=es5 babel scripts --config-file ../../babel.config.js --out-dir dist/scripts --source-maps --ignore 'node_modules/'"
   },
   "sideEffects": false,
   "dependencies": {

--- a/modules/gltf/scripts/glbdump.js
+++ b/modules/gltf/scripts/glbdump.js
@@ -6,6 +6,8 @@ const {toArrayBuffer} = require('@loaders.gl/core');
 
 const fs = require('fs');
 
+const MAX_LENGTH = 76;
+
 function printHelp() {
   console.log('glbdump: no glb files specified...');
   console.log('glbdump --json Pretty prints the JSON chunk...');
@@ -70,14 +72,22 @@ function dumpGLBSegments(data) {
 
 function logArray(key, array) {
   array.forEach((object, i) =>
-    console.log(`${key.toUpperCase()}-${i}: ${JSON.stringify(object).slice(0, 60)}...`)
+    console.log(`${key.toUpperCase()}-${i}: ${JSON.stringify(object).slice(0, MAX_LENGTH)}...`)
   );
 }
 
 function logObject(field, object) {
-  Object.keys(object).forEach((key, i) =>
-    console.log(`${field.toUpperCase()}-${i}: ${JSON.stringify(object[key]).slice(0, 60)}...`)
-  );
+  let prevHeading = null;
+  Object.keys(object).forEach((key, i) => {
+    // Write key once
+    const heading = field.toUpperCase();
+    if (heading !== prevHeading) {
+      console.log(heading);
+      prevHeading = heading;
+    }
+
+    console.log(` ${i}: ${JSON.stringify(object[key]).slice(0, MAX_LENGTH)}...`)
+  });
 }
 
 // GLTF

--- a/modules/gltf/scripts/glbdump.js
+++ b/modules/gltf/scripts/glbdump.js
@@ -1,7 +1,8 @@
 /* global console, process */
 /* eslint-disable no-console */
 
-const {GLBParser, GLTFParser, toArrayBuffer} = require('../src');
+const {GLBParser, GLTFParser} = require('@loaders.gl/gltf');
+const {toArrayBuffer} = require('@loaders.gl/core');
 
 const fs = require('fs');
 

--- a/modules/gltf/scripts/glbdump.js
+++ b/modules/gltf/scripts/glbdump.js
@@ -70,22 +70,26 @@ function dumpGLBSegments(data) {
   }
 }
 
+// Writes heading once
+let prevHeading = null;
+
+function printHeading(heading) {
+  if (heading !== prevHeading) {
+    console.log(heading.toUpperCase());
+    prevHeading = heading;
+  }
+}
+
 function logArray(key, array) {
-  array.forEach((object, i) =>
-    console.log(`${key.toUpperCase()}-${i}: ${JSON.stringify(object).slice(0, MAX_LENGTH)}...`)
-  );
+  array.forEach((object, i) => {
+    printHeading(key);
+    console.log(` ${i}: ${JSON.stringify(object).slice(0, MAX_LENGTH)}...`)
+  });
 }
 
 function logObject(field, object) {
-  let prevHeading = null;
   Object.keys(object).forEach((key, i) => {
-    // Write key once
-    const heading = field.toUpperCase();
-    if (heading !== prevHeading) {
-      console.log(heading);
-      prevHeading = heading;
-    }
-
+    printHeading(field);
     console.log(` ${i}: ${JSON.stringify(object[key]).slice(0, MAX_LENGTH)}...`)
   });
 }


### PR DESCRIPTION
Debugging a glb file for @twojtasz with "missing" images, new glbdump version shows: 

```
[test]$npx glbdump 2-frame.glb

GLB dump of 2-frame.glb:
BUFFERS
 0: {"byteLength":2227448}...
BUFFERVIEWS
 0: {"buffer":0,"byteOffset":0,"byteLength":493588}...
 1: {"buffer":0,"byteOffset":493588,"byteLength":1480764}...
 2: {"buffer":0,"byteOffset":1974352,"byteLength":126262}...
 3: {"buffer":0,"byteOffset":2100616,"byteLength":126832}...
ACCESSORS
 0: {"bufferView":0,"type":"VEC3","componentType":5121,"count":164529}...
 1: {"bufferView":1,"type":"VEC3","componentType":5126,"count":123397}...
IMAGES
 0: {"bufferView":2,"mimeType":"image/png","width":397,"height":120}...
 1: {"bufferView":3,"mimeType":"image/png","width":397,"height":120}...
XVIZ
 0: "xviz/state_update"...
 1: {"update_type":"snapshot","updates":[{"timestamp":1317042272349,"poses":{"/v...
```