### PR TITLE
Add Draco point cloud benchmarks

### DIFF
--- a/test/bench/draco.bench.js
+++ b/test/bench/draco.bench.js
@@ -1,0 +1,46 @@
+import {loadBinaryFile} from '@loaders.gl/core';
+import {DracoEncoder, DracoLoader} from '@loaders.gl/draco';
+import path from 'path';
+
+const POSITIONS =
+  loadBinaryFile(path.resolve(__dirname, '../data/raw-attribute-buffers/lidar-positions.bin')) ||
+  require('test-data/raw-attribute-buffers/lidar-positions.bin');
+
+const COLORS =
+  loadBinaryFile(path.resolve(__dirname, '../data/raw-attribute-buffers/lidar-positions.bin')) ||
+  require('test-data/raw-attribute-buffers/lidar-colors.bin');
+
+const attributes = {
+  POSITIONS: new Float32Array(POSITIONS),
+  COLORS: new Uint8ClampedArray(COLORS)
+};
+
+const dracoEncoder10 = new DracoEncoder({
+  quantization: {
+    POSITION: 10
+  }
+});
+const dracoEncoder14 = new DracoEncoder({
+  quantization: {
+    POSITION: 14
+  }
+});
+const compressedPointCloud10 = dracoEncoder10.encodePointCloud(attributes);
+const compressedPointCloud14 = dracoEncoder14.encodePointCloud(attributes);
+
+export default function dracoBench(bench) {
+  return bench
+    .group('Draco Encode/Decode')
+    .add('DracoEncoder#encode point cloud#quantization=10', () => {
+      dracoEncoder10.encodePointCloud(attributes);
+    })
+    .add('DracoEncoder#encode point cloud#quantization=14', () => {
+      dracoEncoder14.encodePointCloud(attributes);
+    })
+    .add('DracoDecoder#decode point cloud#quantization=10', () => {
+      DracoLoader.parseBinary(compressedPointCloud10);
+    })
+    .add('DracoDecoder#decode point cloud#quantization=14', () => {
+      DracoLoader.parseBinary(compressedPointCloud14);
+    });
+}

--- a/test/bench/index.js
+++ b/test/bench/index.js
@@ -21,9 +21,12 @@
 /* eslint-disable no-console, no-invalid-this */
 import {Bench} from 'probe.gl/bench';
 
+import dracoBench from './draco.bench';
+
 const suite = new Bench();
 
 // add tests
+dracoBench(suite);
 
 // Run the suite
 suite.run();

--- a/test/bench/index.js
+++ b/test/bench/index.js
@@ -23,7 +23,9 @@ import {Bench} from 'probe.gl/bench';
 
 import dracoBench from './draco.bench';
 
-const suite = new Bench();
+const suite = new Bench({
+  minIterations: 10
+});
 
 // add tests
 dracoBench(suite);

--- a/test/start.js
+++ b/test/start.js
@@ -54,6 +54,14 @@ case 'bench':
   require('./bench/index'); // Run the benchmarks
   break;
 
+case 'bench-browser':
+  new BrowserTestDriver().run({
+    process: 'webpack-dev-server',
+    parameters: ['--config', 'test/webpack.config.js', '--env.bench'],
+    exposeFunction: 'testDone'
+  });
+  break;
+
 case 'analyze':
 case 'analyze-size':
   const util = require('util');


### PR DESCRIPTION
Node:

Draco Encode/Decode
├─ DracoEncoder#encode point cloud#quantization=10: 3.68 iterations/s
├─ DracoDecoder#decode point cloud#quantization=10: 2.71 iterations/s
├─ DracoEncoder#encode point cloud#quantization=14: 3.34 iterations/s
├─ DracoDecoder#decode point cloud#quantization=14: 2.88 iterations/s

Browser:

Draco Encode/Decode
├─ DracoEncoder#encode point cloud#quantization=10: 3.65 iterations/s
├─ DracoDecoder#decode point cloud#quantization=10: 2.85 iterations/s
├─ DracoEncoder#encode point cloud#quantization=14: 2.83 iterations/s
├─ DracoDecoder#decode point cloud#quantization=14: 2.78 iterations/s