### PR TITLE
Fix PCD docs typo

### DIFF
--- a/docs/api-reference/loaders/pcd-loader.md
+++ b/docs/api-reference/loaders/pcd-loader.md
@@ -16,7 +16,7 @@ References
 import {PCDLoader} from '@loaders.gl/pcd';
 import {loadFile} from '@loaders.gl/core';
 
-loadFile(url, PCFDoader)
+loadFile(url, PCDLoader)
 .then(({header, attributes}) => {
   // Application code here, e.g:
   // return new Geometry(attributes)


### PR DESCRIPTION
Replaced `PCFDoader` by `PCDLoader` in usage example