### PR TITLE
Fix addImage() on GLTFBuilder

### DIFF
--- a/modules/core/src/parse-file/parse-with-loader.js
+++ b/modules/core/src/parse-file/parse-with-loader.js
@@ -45,7 +45,7 @@ export function parseWithLoaderSync(data, loader, options = {}, url) {
   normalizeLegacyLoaderObject(loader);
 
   // First check for synchronous parsers
-  if (loader.parseTextSync) {
+  if (loader.parseTextSync && typeof data === 'string') {
     return loader.parseTextSync(data, options);
   }
   if (loader.parseSync) {

--- a/modules/gltf/scripts/glbdump.js
+++ b/modules/gltf/scripts/glbdump.js
@@ -44,7 +44,7 @@ function dumpFile(filename) {
 
   const arrayBuffer = toArrayBuffer(binary);
 
-  const data = new GLBParser(arrayBuffer).parse({ignoreMagic: true}).getJSON();
+  const data = new GLBParser().parse(arrayBuffer, {ignoreMagic: true}).getJSON();
 
   if (options.dumpGLTF) {
     dumpGLTFScenes(data);
@@ -97,8 +97,8 @@ function logObject(field, object) {
 // GLTF
 
 function dumpGLTFScenes(data) {
-  const gltfParser = new GLTFParser(data);
-  const gltf = gltfParser.resolve();
+  const gltfParser = new GLTFParser();
+  const gltf = gltfParser.parse(data);
   if (gltf.asset) {
     console.log(JSON.stringify(gltf.asset, null, 2));
   }

--- a/modules/gltf/src/gltf/gltf-loader.js
+++ b/modules/gltf/src/gltf/gltf-loader.js
@@ -1,15 +1,13 @@
 // Binary container format for glTF
 
-import GLBParser from '../glb/glb-parser';
 import GLTFParser from './gltf-parser';
 
 export function parseTextGLTF(json, options = {}) {
-  return new GLTFParser(json).parse(options);
+  return new GLTFParser().parse(json, options);
 }
 
 export function parseBinaryGLTF(glbArrayBuffer, options = {}) {
-  const {json, arrayBuffer} = new GLBParser(glbArrayBuffer).parse(options);
-  return new GLTFParser(json, arrayBuffer).parse(options);
+  return new GLTFParser().parse(glbArrayBuffer, options);
 }
 
 export default {

--- a/modules/gltf/test/glb/glb-builder.spec.js
+++ b/modules/gltf/test/glb/glb-builder.spec.js
@@ -152,6 +152,26 @@ test('GLBBuilder#encode complex', t => {
   t.end();
 });
 
+// TODO(twojtasz): I removed the addImageEntry as this is a GLTF property change
+// I think this test may be redundant with GLTF tests
+test.skip('GLBBuilder#addImageEntry', t => {
+  const builder = new GLBBuilder();
+  const firstImageIndex = builder.addImageEntry(3, {mimeType: 'image/png', width: 100, height: 101});
+  const secondImageIndex = builder.addImageEntry(2, {mimeType: 'image/png', width: 200, height: 201});
+
+  t.equal(builder.json.images.length, 2, 'images has 2 entries');
+
+  t.equal(firstImageIndex, 0, 'first addImageEntry has image index of 0');
+  const expectedFirst = {bufferView: 3, width: 100, height: 101, mimeType: 'image/png'};
+  t.deepEqual(builder.json.images[0], expectedFirst, 'first images entry matches');
+
+  t.equal(secondImageIndex, 1, 'second addImageEntry has image index of 1');
+  const expectedSecond = {bufferView: 2, width: 200, height: 201, mimeType: 'image/png'};
+  t.deepEqual(builder.json.images[1], expectedSecond, 'second images entry matches');
+
+  t.end();
+});
+
 test('pack-and-unpack-binary-buffers', t => {
   const glbBuilder = new GLBBuilder();
 

--- a/modules/gltf/test/gltf/gltf-builder.spec.js
+++ b/modules/gltf/test/gltf/gltf-builder.spec.js
@@ -1,0 +1,29 @@
+/* eslint-disable max-len */
+import test from 'tape-promise/tape';
+
+import {GLTFBuilder} from '@loaders.gl/gltf';
+
+const PNG1x1 = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4, 0x89, 0x00, 0x00, 0x00, 0x0a, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9c, 0x63, 0x00, 0x01, 0x00, 0x00, 0x05, 0x00, 0x01, 0x0a]);
+
+test('GLTFBuilder#ctor', t => {
+  const gltfBuilder = new GLTFBuilder();
+  t.equal(0, gltfBuilder.getByteLength(), 'New builder has 0 byte length');
+  t.end();
+});
+
+test('GLTFBuilder#addImage', t => {
+  // Smallest valid png
+  const gltfBuilder = new GLTFBuilder();
+  const imageIndex = gltfBuilder.addImage(PNG1x1);
+  t.equal(imageIndex, 0, 'Image index should be 0');
+
+  t.deepEquals(gltfBuilder._getInternalCounts(), {buffers: 1, bufferViews: 1, accessors: 0, images: 1}, 'gltf properties set as expected');
+
+  const {bufferView, mimeType, width, height} = gltfBuilder.json.images[0];
+  t.equal(bufferView, 0, 'bufferView index is 0');
+  t.equal(mimeType, 'image/png', 'mimeType is png');
+  t.equal(width, 1, 'width is 1');
+  t.equal(height, 1, 'height is 1');
+
+  t.end();
+});

--- a/modules/gltf/test/gltf/gltf-loader.spec.js
+++ b/modules/gltf/test/gltf/gltf-loader.spec.js
@@ -2,7 +2,7 @@
 import test from 'tape-promise/tape';
 
 import {deepCopy} from 'test/setup';
-import {readFileSync} from '@loaders.gl/core';
+import {parseFileSync, readFileSync} from '@loaders.gl/core';
 import {GLBParser, GLTFLoader, GLTFParser} from '@loaders.gl/gltf';
 import path from 'path';
 
@@ -34,5 +34,17 @@ test('GLTFParser#parse binary', t => {
   const gltf = new GLTFParser().parse(json);
   t.ok(gltf, 'GLTFParser returned parsed data');
 
+  t.end();
+});
+
+test('GLTFParser#parseFileSync binary', t => {
+  const data = parseFileSync(GLTF_BINARY, GLTFLoader);
+  t.ok(data.asset, 'GLTFLoader returned parsed data');
+  t.end();
+});
+
+test('GLTFParser#parseFileSync text', t => {
+  const data = parseFileSync(GLTF_JSON, GLTFLoader);
+  t.ok(data.asset, 'GLTFLoader returned parsed data');
   t.end();
 });

--- a/modules/gltf/test/gltf/index.js
+++ b/modules/gltf/test/gltf/index.js
@@ -1,3 +1,4 @@
+import './gltf-builder.spec';
 import './gltf-loader.spec';
 import './gltf-roundtrip.spec';
 import './gltf-draco.spec';


### PR DESCRIPTION
GLTFBuilder API retains the addImage() method, but it is implemented
at the GLTF layer rather than in the GLBBuilder.

The GLTFBuilder is responsible for adding the BufferView, then
passing that bufferViewIndex to create the images entry.

Currently the 'images' entry is managed by the GLBBuilder, but
eventually that can move to the GLTFBuilder as well.

- remove addApplicationData() from GLTF as it was a duplicate of the
  GLBBuilder, and the GLBBuilder currently manages the json object

- Fix bug in addApplicationData() that did not set the key value if
  the option 'nopack' was 'true'