### PR TITLE
add publishConfig to arrow & images modules

### DIFF
--- a/modules/arrow/package.json
+++ b/modules/arrow/package.json
@@ -3,6 +3,9 @@
   "version": "0.6.2",
   "description": "Simple columnar table loader for the Apache Arrow format",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/uber-web/loaders.gl"

--- a/modules/images/package.json
+++ b/modules/images/package.json
@@ -3,6 +3,9 @@
   "version": "0.6.2",
   "description": "Framework-independent loaders and writers for images (PNG, JPG, ...)",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/uber-web/loaders.gl"


### PR DESCRIPTION
This is was required when publishing 0.6.2