### PR TITLE
Fix missing "regenerator" support in workers

### DIFF
--- a/aliases.js
+++ b/aliases.js
@@ -40,8 +40,13 @@ const makeAliases = () => ({
 const ALIASES = makeAliases();
 
 if (module.require) {
-  const moduleAlias = module.require('module-alias');
-  moduleAlias.addAliases(ALIASES);
+  try {
+    // Note: ignored in browsers through top-level package.json
+    const moduleAlias = module.require('module-alias');
+    moduleAlias.addAliases(ALIASES);
+    // eslint-disable-next-line
+  } catch (error) {
+  }
 }
 
 module.exports = ALIASES;

--- a/aliases.js
+++ b/aliases.js
@@ -39,14 +39,4 @@ const makeAliases = () => ({
 
 const ALIASES = makeAliases();
 
-if (module.require) {
-  try {
-    // Note: ignored in browsers through top-level package.json
-    const moduleAlias = module.require('module-alias');
-    moduleAlias.addAliases(ALIASES);
-    // eslint-disable-next-line
-  } catch (error) {
-  }
-}
-
 module.exports = ALIASES;

--- a/babel.config.js
+++ b/babel.config.js
@@ -10,16 +10,9 @@ const TARGETS = {
 const CONFIG = {
   default: {
     presets: [
-      ['@babel/env', {
-        targets: TARGETS
-      }]
+      // Rewritten by each target
     ],
     plugins: [
-      ['babel-plugin-inline-import', {
-        extensions: [
-          '.worker.js'
-        ]
-      }]
     ],
     ignore: [
       '**/*.worker.js'
@@ -27,13 +20,24 @@ const CONFIG = {
   }
 };
 
+const PLUGINS = [
+  ['babel-plugin-inline-import', {
+    extensions: [
+      '.worker.js'
+    ]
+  }]
+];
+
 CONFIG.es6 = Object.assign({}, CONFIG.default, {
   presets: [
     ['@babel/env', {
       targets: TARGETS,
       modules: false
     }]
-  ]
+  ],
+  plugins: PLUGINS.concat([
+    ['@babel/plugin-transform-runtime', {useESModules: true}]
+  ])
 });
 
 CONFIG.esm = Object.assign({}, CONFIG.default, {
@@ -41,7 +45,10 @@ CONFIG.esm = Object.assign({}, CONFIG.default, {
     ['@babel/env', {
       modules: false
     }]
-  ]
+  ],
+  plugins: PLUGINS.concat([
+    ['@babel/plugin-transform-runtime', {useESModules: true}]
+  ])
 });
 
 CONFIG.es5 = Object.assign({}, CONFIG.default, {
@@ -50,7 +57,10 @@ CONFIG.es5 = Object.assign({}, CONFIG.default, {
       forceAllTransforms: true,
       modules: 'commonjs'
     }]
-  ]
+  ],
+  plugins: PLUGINS.concat([
+    ['@babel/plugin-transform-runtime', {useESModules: false}]
+  ])
 });
 
 CONFIG.cover = Object.assign({}, CONFIG.default);
@@ -65,7 +75,8 @@ module.exports = function getConfig(api) {
   const config = CONFIG[env] || CONFIG.default;
   // Uncomment to debug
   // eslint-disable-next-line
-  // console.error(env, config.plugins);
+  // console.error(env, JSON.stringify(config, null, 2));
+  // throw new Error(JSON.stringify(config, null, 2));
   return config;
 };
 

--- a/modules/draco/package.json
+++ b/modules/draco/package.json
@@ -36,6 +36,7 @@
   },
   "sideEffects": false,
   "dependencies": {
+    "@babel/runtime": "^7.3.1",
     "@loaders.gl/core": "^0.6.2",
     "draco3d": "^1.3.4"
   }

--- a/modules/las/package.json
+++ b/modules/las/package.json
@@ -41,6 +41,7 @@
   },
   "sideEffects": false,
   "dependencies": {
+    "@babel/runtime": "^7.3.1",
     "@loaders.gl/core": "^0.6.2"
   }
 }

--- a/modules/obj/package.json
+++ b/modules/obj/package.json
@@ -36,6 +36,7 @@
   },
   "sideEffects": false,
   "dependencies": {
+    "@babel/runtime": "^7.3.1",
     "@loaders.gl/core": "^0.6.2",
     "webgl-obj-loader": "^1.1.3"
   }

--- a/modules/ply/package.json
+++ b/modules/ply/package.json
@@ -36,6 +36,7 @@
   },
   "sideEffects": false,
   "dependencies": {
+    "@babel/runtime": "^7.3.1",
     "@loaders.gl/core": "^0.6.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
   "workspaces": [
     "modules/*"
   ],
+  "browser": {
+    "module-alias": false
+  },
   "scripts": {
     "start": "echo 'Please see loaders.gl website for how to run examples' && open https://uber-web.github.io/loaders.gl/#/docs/overview/introduction",
     "bootstrap": "scripts/bootstrap.sh",
@@ -45,8 +48,8 @@
     "@babel/core": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
     "@babel/register": "^7.0.0",
+    "@babel/plugin-transform-runtime": "^7.0.0",
     "@probe.gl/test-utils": "^3.0.0-alpha.2",
-    "@std/esm": "^0.26.0",
     "arraybuffer-loader": "^1.0.6",
     "babel-eslint": "^9.0.0",
     "babel-loader": "^8.0.0",
@@ -57,7 +60,6 @@
     "eslint": "^3.0",
     "eslint-config-uber-es2015": "^3.0.0",
     "eslint-plugin-babel": "^5.1.0",
-    "esm": "^3.2.4",
     "html-webpack-plugin": "^3.0.7",
     "lerna": "^2.9.1",
     "luma.gl": "^6.4.0",

--- a/package.json
+++ b/package.json
@@ -22,9 +22,6 @@
   "workspaces": [
     "modules/*"
   ],
-  "browser": {
-    "module-alias": false
-  },
   "scripts": {
     "start": "echo 'Please see loaders.gl website for how to run examples' && open https://uber-web.github.io/loaders.gl/#/docs/overview/introduction",
     "bootstrap": "scripts/bootstrap.sh",

--- a/scripts/worker-webpack-config.js
+++ b/scripts/worker-webpack-config.js
@@ -16,7 +16,8 @@
 const ALIASES = require('../aliases');
 
 const BABEL_CONFIG = {
-  presets: [['@babel/env', {modules: 'commonjs'}]]
+  presets: [['@babel/env', {modules: 'commonjs'}]],
+  plugins: [['@babel/plugin-transform-runtime', {useESModules: false}]]
 };
 
 module.exports = {
@@ -31,7 +32,7 @@ module.exports = {
   module: {
     rules: [
       {
-        // Compile ES2015 using bable
+        // Compile ES2015 using babel
         test: /\.js$/,
         exclude: /node_modules/,
         use: [
@@ -43,7 +44,7 @@ module.exports = {
       }
     ]
   },
-  
+
   node: {
     fs: 'empty'
   }

--- a/test/start.js
+++ b/test/start.js
@@ -8,12 +8,9 @@ const path = require('path');
 const moduleAlias = require('module-alias');
 const {BrowserTestDriver} = require('@probe.gl/test-utils');
 
-// esm - Enables ES2015 import/export in Node.js.
-// TODO - can't get esm to work with module-alias
-// require = require('esm')(module, true); // true: read options from .esmrc.js
-
 // Sets up aliases in node
-require('../aliases');
+const ALIASES = require('../aliases');
+moduleAlias.addAliases(ALIASES);
 
 const mode = process.argv.length >= 3 ? process.argv[2] : 'default';
 const arg = process.argv.length >= 4 ? process.argv[3] : 'default';

--- a/yarn.lock
+++ b/yarn.lock
@@ -496,6 +496,16 @@
   dependencies:
     regenerator-transform "^0.13.3"
 
+"@babel/plugin-transform-runtime@^7.0.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.2.0.tgz#566bc43f7d0aedc880eaddbd29168d0f248966ea"
+  integrity sha512-jIgkljDdq4RYDnJyQsiWbdvGeei/0MOTtSHKO/rfbd/mXBxNpdlulMx49L0HQ4pug1fXannxoqCI+fYSle9eSw==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    resolve "^1.8.1"
+    semver "^5.5.1"
+
 "@babel/plugin-transform-shorthand-properties@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz#6333aee2f8d6ee7e28615457298934a3b46198f0"
@@ -660,11 +670,6 @@
     pixelmatch "^4.0.2"
     probe.gl "^3.0.0-alpha.3"
     puppeteer "1.8.0"
-
-"@std/esm@^0.26.0":
-  version "0.26.0"
-  resolved "https://registry.yarnpkg.com/@std/esm/-/esm-0.26.0.tgz#c3ec3abdee95738e15ea7c695b7fee14ae529b81"
-  integrity sha512-g3RDuosSa5fZOzENtrZdx7Gevb3zabfn8qglug2aCJIVz/4woFpKoqm1yD3mG2RD0zJEZRnkkuPHsmNglKGl7g==
 
 "@types/flatbuffers@1.6.5":
   version "1.6.5"
@@ -2916,11 +2921,6 @@ eslint@^3.0:
     table "^3.7.8"
     text-table "~0.2.0"
     user-home "^2.0.0"
-
-esm@^3.2.4:
-  version "3.2.6"
-  resolved "https://registry.yarnpkg.com/esm/-/esm-3.2.6.tgz#879e4888e631a6893f2afc24adb23d4dbe8fad30"
-  integrity sha512-3wWjSurKSczMzYyHiBih3VVEQYCoZa6nfsqqcM2Tx6KBAQAeor0SZUfAol+zeVUtESLygayOi2ZcMfYZy7MCsg==
 
 espree@^3.4.0:
   version "3.5.4"
@@ -6813,7 +6813,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.1.6, resolve@^1.10.0, resolve@^1.3.2, resolve@~1.10.0:
+resolve@^1.1.6, resolve@^1.10.0, resolve@^1.3.2, resolve@^1.8.1, resolve@~1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.10.0.tgz#3bdaaeaf45cc07f375656dfd2e54ed0810b101ba"
   integrity sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==
@@ -6967,7 +6967,7 @@ selfsigned@^1.9.1:
   dependencies:
     node-forge "0.7.5"
 
-"semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.6.0:
+"semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
   integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3330,7 +3330,7 @@ flat-cache@^1.2.1:
     rimraf "~2.6.2"
     write "^0.2.1"
 
-"flatbuffers@github:trxcllnt/flatbuffers-esm":
+flatbuffers@trxcllnt/flatbuffers-esm:
   version "1.7.0"
   resolved "https://codeload.github.com/trxcllnt/flatbuffers-esm/tar.gz/0ed890546a45c361665b1778f856b4a48cc22c8a"
 


### PR DESCRIPTION
This issue has been preventing the update of deck.gl examples to use loaders.gl.