### PR TITLE
Safe svg loading

### DIFF
--- a/modules/core/src/image-utils/image-loaders.js
+++ b/modules/core/src/image-utils/image-loaders.js
@@ -31,6 +31,7 @@ function loadToHTMLImage(url, options) {
   if (/\.svg((\?|#).*)?$/.test(url)) {
     // is SVG
     promise = readFile(url, {dataType: 'text'})
+      // base64 encoding is safer. utf-8 fails in some browsers
       .then(xml => `data:image/svg+xml;base64,${btoa(xml)}`);
   } else {
     promise = Promise.resolve(url);

--- a/modules/core/src/image-utils/image-loaders.js
+++ b/modules/core/src/image-utils/image-loaders.js
@@ -31,7 +31,7 @@ function loadToHTMLImage(url, options) {
   if (/\.svg((\?|#).*)?$/.test(url)) {
     // is SVG
     promise = readFile(url, {dataType: 'text'})
-      .then(xml => `data:image/svg+xml;charset=utf-8,${xml}`);
+      .then(xml => `data:image/svg+xml;base64,${btoa(xml)}`);
   } else {
     promise = Promise.resolve(url);
   }

--- a/modules/core/src/image-utils/image-loaders.js
+++ b/modules/core/src/image-utils/image-loaders.js
@@ -1,4 +1,4 @@
-/* global Image, Blob, createImageBitmap */
+/* global Image, Blob, createImageBitmap, btoa */
 import {readFile} from '../read-file/read-file';
 
 // Specifically loads an ImageBitmap (works on newer browser main and worker threads)


### PR DESCRIPTION
Using utf8 in data URL fails in the latest Chrome.