### PR TITLE
Add parser support for KHR_lights_punctual glTF extension

### DIFF
--- a/docs/api-reference/gltf-loaders/gltf-extensions.md
+++ b/docs/api-reference/gltf-loaders/gltf-extensions.md
@@ -6,7 +6,6 @@ Many glTF extensions affect e.g. rendering which is outside of the scope of load
 
 ## Official Extensions
 
-
 ### KHR_draco_mesh_compression
 
 Supports compression of mesh attributes (geometry).
@@ -15,14 +14,13 @@ Specification: [KHR_draco_mesh_compression](https://github.com/KhronosGroup/glTF
 
 Parsing Support:
 
-* By adding the `decompress: true` options to the `GLTFParser` any decompressed by the `GLTFParser`.
-* The expanded attributes are placed in the mesh object (effectively making it look as if it had never been compressed).
-* The extension objects are removed from the glTF file.
+- By adding the `decompress: true` options to the `GLTFParser` any decompressed by the `GLTFParser`.
+- The expanded attributes are placed in the mesh object (effectively making it look as if it had never been compressed).
+- The extension objects are removed from the glTF file.
 
 Encoding Support:
 
-* Meshes can be compressed as they are added to the `GLTFBuilder`.
-
+- Meshes can be compressed as they are added to the `GLTFBuilder`.
 
 ### KHR_lights_punctual
 
@@ -32,13 +30,13 @@ Specification: [KHR_lights_punctual](https://github.com/KhronosGroup/glTF/tree/m
 
 Parsing Support:
 
-* Removal of extension wrappers (happens during glTF postprocessing)
-* A `lights` array will be added to the list of glTF arrays.
-* Any nodes with a light extension will get a `light` field with value set to the light definition object (from the `lights` array).
+- Any nodes with a `KHR_lights_punctual` extension will get a `light` field with value containing a light definition object with properties defining the light (this object will be resolved by index from the global `KHR_lights_punctual` extension object's `lights` array) .
+- The `KHR_lights_punctual` extensions will be removed from all nodes.
+- Finally, the global `KHR_lights_punctual` extension (including its light list)) will be removed.
 
 Encoding Support:
 
-* N/A
+- N/A
 
 ## Custom Extensions
 
@@ -48,9 +46,9 @@ Specification: Similar to `KHR_draco_mesh_compression`, but supports point cloud
 
 Parsing support:
 
-* The primitive's accessors field will be populated after decompression.
-* After decompression, the extension will be removed (as if the point cloud was never compressed).
+- The primitive's accessors field will be populated after decompression.
+- After decompression, the extension will be removed (as if the point cloud was never compressed).
 
 Encoding support:
 
-* Point clouds can be compressed as they are added to the `GLTFBuilder` and decompressed by the `GLTFParser`.
+- Point clouds can be compressed as they are added to the `GLTFBuilder` and decompressed by the `GLTFParser`.

--- a/docs/api-reference/gltf-loaders/gltf-extensions.md
+++ b/docs/api-reference/gltf-loaders/gltf-extensions.md
@@ -6,16 +6,51 @@ Many glTF extensions affect e.g. rendering which is outside of the scope of load
 
 ## Official Extensions
 
+
 ### KHR_draco_mesh_compression
 
-Description: [KHR_draco_mesh_compression](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_draco_mesh_compression).
+Supports compression of mesh attributes (geometry).
 
-This extension is partially implemented. Meshes can be compressed as they are added to the `GLTFBuilder` and decompressed by the `GLTFParser`.
+Specification: [KHR_draco_mesh_compression](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_draco_mesh_compression).
+
+Parsing Support:
+
+* By adding the `decompress: true` options to the `GLTFParser` any decompressed by the `GLTFParser`.
+* The expanded attributes are placed in the mesh object (effectively making it look as if it had never been compressed).
+* The extension objects are removed from the glTF file.
+
+Encoding Support:
+
+* Meshes can be compressed as they are added to the `GLTFBuilder`.
+
+
+### KHR_lights_punctual
+
+Supports specification of point light sources and addition of such sources to the scenegraph node.
+
+Specification: [KHR_lights_punctual](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_lights_punctual)
+
+Parsing Support:
+
+* Removal of extension wrappers (happens during glTF postprocessing)
+* A `lights` array will be added to the list of glTF arrays.
+* Any nodes with a light extension will get a `light` field with value set to the light definition object (from the `lights` array).
+
+Encoding Support:
+
+* N/A
 
 ## Custom Extensions
 
 ### UBER_draco_point_cloud_compression
 
-Description: Similar to `KHR_draco_mesh_compression`, but does not contain any accessors and does not support any fallback or non-compressed accessors/attributes. The primitive's accessors field will be populated after decompression.
+Specification: Similar to `KHR_draco_mesh_compression`, but supports point clouds (draw mode 0). Also does not support any fallback or non-compressed accessors/attributes.
 
-Point clouds can be compressed as they are added to the `GLTFBuilder` and decompressed by the `GLTFParser`.
+Parsing support:
+
+* The primitive's accessors field will be populated after decompression.
+* After decompression, the extension will be removed (as if the point cloud was never compressed).
+
+Encoding support:
+
+* Point clouds can be compressed as they are added to the `GLTFBuilder` and decompressed by the `GLTFParser`.

--- a/docs/api-reference/gltf-loaders/gltf-parser.md
+++ b/docs/api-reference/gltf-loaders/gltf-parser.md
@@ -7,6 +7,8 @@ To facilitiate working with the loaded data, the `GLTFParser` class provides:
 - A set of accessor methods to facilitate traversal the parsed glTF data.
 - A `resolveScenegraphs` method that resolves the index based linking between objects into a hierarchical javascript structure.
 
+Certain glTF extensions can be fully or partially processed by the `GLTFParser`. See [glTF Extensions](docs/api-reference/gltf-loaders/gltf-extensions.md).
+
 References:
 
 - For more information, see [glTF and GLB support](docs/) in the Developer's Guide.
@@ -54,24 +56,24 @@ Calling the `resolveScenegraphs` method adds a hierarchical structure that makes
 
 ## Methods
 
-### constructor(options : Object)
+### constructor()
 
 Creates a new `GLTFParser` instance.
 
-- `options.DracoDecoder` - To enable DRACO encoding, the application needs to import and supply the DracoEncoder class.
+### async parse(arrayBuffer : ArrayBuffer, options : Object) : Promise<Object>
 
-### async parse(arrayBuffer : ArrayBuffer) : Promise<Object>
+Parses an in-memory, glTF/GLB formatted `ArrayBuffer` a JSON tree with binary typed arrays and image nodes. Once the `Promise` returned by the `parse()` method has successfully resolved, the accessors in this class can be used.
 
-Parses an in-memory, glTF/GLB formatted `ArrayBuffer` a JSON tree with binary typed arrays and image nodes.
-
-Once the `parse()` method has successfully completed the accessors in this class can be used.
+- `options.url`= - Supplies a base URL that is used to resolve relative file names to linked resources. Only needed when loading glTF files that have linked resources (e.g. typically not the case for `.glb` encoded files).
+- `options.decompress`=`false` - Decompresses any Draco encoded meshes
+- `options.DracoDecoder` - To enable Draco encoding, the application also needs to import and supply the `DracoEncoder` class.
 
 Notes:
 
 - linked binary resources will be loaded and resolved (if url is available).
 - base64 encoded binary data inside the JSON payload will be decoded
 
-### parseSync(arrayBuffer : ArrayBuffer) : Object
+### parseSync(arrayBuffer : ArrayBuffer, options : Object) : Object
 
 Parses an in-memory, glTF/GLB formatted `ArrayBuffer` a JSON tree with binary typed arrays and image nodes.
 

--- a/modules/gltf/test/gltf/gltf-post-processor.spec.js
+++ b/modules/gltf/test/gltf/gltf-post-processor.spec.js
@@ -1,0 +1,57 @@
+/* eslint-disable max-len, camelcase */
+import test from 'tape-promise/tape';
+
+import GLTFPostProcessor from '@loaders.gl/gltf/gltf/gltf-post-processor';
+
+const TEST_CASES = [
+  {
+    name: 'KHR_lights_punctual',
+    gltf: {
+      extensionsUsed: ['KHR_lights_punctual'],
+      extensions: {
+        KHR_lights_punctual: {
+          lights: [
+            {
+              color: [1.0, 1.0, 1.0],
+              type: 'directional'
+            }
+          ]
+        }
+      },
+      nodes: [
+        {
+          extensions: {
+            KHR_lights_punctual: {
+              light: 0
+            }
+          }
+        }
+      ]
+    },
+    postProcessed: {
+      extensionsUsed: [],
+      extensions: {},
+      nodes: [
+        {
+          extensions: {},
+          id: 'node-0',
+          children: [],
+          light: {
+            color: [1.0, 1.0, 1.0],
+            type: 'directional'
+          }
+        }
+      ]
+    }
+  }
+];
+
+test('GLTF roundtrip#extensions', t => {
+  const postProcessor = new GLTFPostProcessor();
+  const gltf = TEST_CASES[0].gltf;
+  postProcessor.postProcess(gltf);
+
+  t.deepEqual(TEST_CASES[0].gltf, TEST_CASES[0].postProcessed, TEST_CASES[0].name);
+
+  t.end();
+});

--- a/modules/gltf/test/index.js
+++ b/modules/gltf/test/index.js
@@ -10,3 +10,4 @@ import './gltf/gltf-builder.spec';
 import './gltf/gltf-loader.spec';
 import './gltf/gltf-roundtrip.spec';
 import './gltf/gltf-draco.spec';
+import './gltf/gltf-post-processor.spec';


### PR DESCRIPTION
Since we are adding light support to luma.gl v7 we can support glTF lights. And by doing so we make sure our lights support the "right" set of parameters from the start.

See [KHR_lights_punctual](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_lights_punctual)

This parse code just removes the extension objects from the glTF JSON and makes it look like the light info is a natural part of the "node".