### PR TITLE
Add loader registry

### DIFF
--- a/docs/api-reference/core/load-file.md
+++ b/docs/api-reference/core/load-file.md
@@ -1,28 +1,28 @@
 # loadFile
 
-`loadFile` and `loadFileSync` function can be used with any loader. `loadFile` takes a `url` and a loader object, checks what type of data that loader prefers to work on (e.g. text, JSON, binary, stream, ...), loads the data in the appropriate way, and passes it to the loader.
+`loadFile` and `loadFileSync` function can be used with any *loader object*. They takes a `url` and one or more *loader objects*, checks what type of data that loader prefers to work on (e.g. text, JSON, binary, stream, ...), loads the data in the appropriate way, and passes it to the loader.
 
-## Functions
+### loadFile(url : String | File, loaders : Object | Object[] [, options : Object]) : Promise<Response>
+### loadFile(url : String | File [, options : Object]) : Promise<Response>
 
-### fetchFile(url : String | File, loader : Object [, options : Object]) : Promise<Response>
+The `loadFile` function is used to load and parse data with a specific *loader object*. An array of loader objects can be provided, in which case `loadFile` will attempt to autodetect which loader is appropriate for the file.
 
-The `loadFile` function can be used with any loader.
-
-`loadFile` takes a `url` and a loader object, checks what type of data that loader prefers to work on (e.g. text, JSON, binary, stream, ...), loads the data in the appropriate way, and passes it to the loader.
+The `loaders` parameter can also be ommitted, in which case any *loader objects* previously registered with [`registerLoaders`](docs/api-reference/core/register-loaders) will be used.
 
 - `url` - Can be a string, either a data url or a request url, or in Node.js, a file name, or in the browser, a File object.
 - `data` - loaded data, either in binary or text format.
-- `loader` - can be a single loader or an array of loaders.
+- `loaders` - can be a single loader or an array of loaders. If ommitted, will use the list of registered loaders (see `registerLoaders`)
 - `options` - optional, contains both options for the read process and options for the loader (see documentation of the specific loader).
 - `options.dataType`=`arraybuffer` - By default reads as binary. Set to 'text' to read as text.
 
 Returns:
 
-- Return value depends on the category
+- Return value depends on the *loader object* category
 
 Notes:
 
 - Any path prefix set by `setPathPrefix` will be appended to relative urls.
+- `loadFile` takes a `url` and a loader object, checks what type of data that loader prefers to work on (e.g. text, binary, stream, ...), loads the data in the appropriate way, and passes it to the loader.
 
 ### loadFileSync(url : String [, options : Object]) : ArrayBuffer | String
 

--- a/docs/api-reference/core/parse-file.md
+++ b/docs/api-reference/core/parse-file.md
@@ -1,8 +1,10 @@
 # parseFile
 
+This function parses already loaded data. As a special case, it can also load (and then parse) data from  `fetch` or `fetchFile` response object).
+
 ## Usage
 
-The return value from `fetch` or `fetchFile` is a `Promise` that resolves to the fetch response object and can be passed directly to the (non-sync) parser functions:
+The return value from `fetch` or `fetchFile` is a `Promise` that resolves to the fetch response object and can be passed directly to the non-sync parser functions:
 
 ```js
 import {fetchFile, parseFile} from '@loaders.gl/core';
@@ -13,9 +15,30 @@ data = await parseFile(fetchFile(url), OBJLoader);
 ...
 ```
 
+Batched (streaming) parsing is supported by some loaders
+
+```js
+import {fetchFile, parseFileInBatches} from '@loaders.gl/core';
+import {CSVLoader} from '@loaders.gl/obj';
+
+const batchIterator = await parseFileInBatches(fetchFile(url), CSVLoader);
+for await (const batch of batchIterator) {
+  console.log(batch.length);
+}
+````
+
 ## Functions
 
-### parseFileInBatches(data : any, loader : Object | Array [, options : Object [, url : String]]) : AsyncIterator
+### parseFileInBatches(data : any, loaders : Object | Object\[] [, options : Object [, url : String]]) : AsyncIterator
+### parseFileInBatches(data : any [, options : Object [, url : String]]) : AsyncIterator
+
+> Batched loading is not supported by all *loader objects*
+
+Parses data in batches from a stream, releasing each batch to the application while the stream is still being read.
+
+Parses data with the selected *loader object*. An array of `loaders` can be provided, in which case an attempt will be made to autodetect which loader is appropriate for the file (using url extension and header matching).
+
+The `loaders` parameter can also be ommitted, in which case any *loader objects* previously registered with [`registerLoaders`](docs/api-reference/core/register-loaders) will be used.
 
 - `data`: loaded data or an object that allows data to be loaded. This parameter can be any of the following types:
   - `Response` - `fetch` response object returned by `fetchFile` or `fetch`.
@@ -25,13 +48,22 @@ data = await parseFile(fetchFile(url), OBJLoader);
   - `AsyncIterator` - iterator that yeilds promises that resolve to binary (`ArrayBuffer`) chunks or string chunks.
   - `ReadableStream` - A DOM or Node stream.
   - `Promise` - A promise that resolves to any of the other supported data types can also be supplied.
-- `loader`: can be a single loader or an array of loaders.
+- `loaders` - can be a single loader or an array of loaders. If ommitted, will use the list of registered loaders (see `registerLoaders`)
 - `options`: optional, options for the loader (see documentation of the specific loader).
 - `url`: optional, assists in the autoselection of a loader if multiple loaders are supplied to `loader`.
 
-### parseFile(data : ArrayBuffer | String, loader : Object | Array [, options : Object [, url : String]]) : Promise<Any>
+Returns:
+
+- Returns an async iterator that yields batches of data. The exact format for the batches depends on the *loader object* category.
+
+
+### parseFile(data : ArrayBuffer | String, loaders : Object | Object\[] [, options : Object [, url : String]]) : Promise<Any>
+### parseFile(data : ArrayBuffer | String, [, options : Object [, url : String]]) : Promise<Any>
 
 Parses data asynchronously using the provided loader.
+Used to parse data with a selected *loader object*. An array of `loaders` can be provided, in which case an attempt will be made to autodetect which loader is appropriate for the file (using url extension and header matching).
+
+The `loaders` parameter can also be ommitted, in which case any *loader objects* previously registered with [`registerLoaders`](docs/api-reference/core/register-loaders) will be used.
 
 - `data`: loaded data or an object that allows data to be loaded. This parameter can be any of the following types:
   - `Response` - `fetch` response object returned by `fetchFile` or `fetch`.
@@ -41,15 +73,23 @@ Parses data asynchronously using the provided loader.
   - `AsyncIterator` - iterator that yeilds promises that resolve to binary (`ArrayBuffer`) chunks or string chunks.
   - `ReadableStream` - A DOM or Node stream.
   - `Promise` - A promise that resolves to any of the other supported data types can also be supplied.
-- `loader`: can be a single loader or an array of loaders.
+- `loaders` - can be a single loader or an array of loaders. If ommitted, will use the list of registered loaders (see `registerLoaders`)
 - `options`: optional, options for the loader (see documentation of the specific loader).
 - `url`: optional, assists in the autoselection of a loader if multiple loaders are supplied to `loader`.
 
 - `options.log`=`console` Any object with methods `log`, `info`, `warn` and `error`. By default set to `console`. Setting log to `null` will turn off logging.
 
-### parseFileSync(fileData : ArrayBuffer | String, loader : Object | Array, [, options : Object [, url : String]]) : any
+Returns:
 
-Parses data synchronously using the provided loader, if possible. If not, returns `null`, in which case asynchronous loading is required.
+- Return value depends on the *loader object* category
+
+
+### parseFileSync(fileData : ArrayBuffer | String, loaders : Object | Object\[], [, options : Object [, url : String]]) : any
+### parseFileSync(fileData : ArrayBuffer | String, [, options : Object [, url : String]]) : any
+
+> Synchronous parsing is not supported by all *loader objects*
+
+Parses data synchronously using the provided loader, if possible. If not, returns `null`, in which case asynchronous parsing is required.
 
 - `data`: already loaded data, either in binary or text format. This parameter can be any of the following types:
   - `Response`: `fetch` response object returned by `fetchFile` or `fetch`.
@@ -57,6 +97,10 @@ Parses data synchronously using the provided loader, if possible. If not, return
   - `String`: Parse from text data in a string. (Only works for loaders that support textual input).
   - `Iterator`: Iterator that yeilds binary (`ArrayBuffer`) chunks or string chunks (string chunks only work for loaders that support textual input).
     can also be supplied.
-- `loader`: can be a single loader or an array of loaders.
+- `loaders` - can be a single loader or an array of loaders. If ommitted, will use the list of registered loaders (see `registerLoaders`)
 - `options`: optional, options for the loader (see documentation of the specific loader).
 - `url`: optional, assists in the autoselection of a loader if multiple loaders are supplied to `loader`.
+
+Returns:
+
+- Return value depends on the *loader object* category

--- a/docs/api-reference/core/register-loaders.md
+++ b/docs/api-reference/core/register-loaders.md
@@ -18,7 +18,7 @@ Some other file that needs to load CSV:
 ```js
 import {loadFile} from '@loaders.gl/core';
 
-// The pre-registered SVLoader gets auto selected based on file extension...
+// The pre-registered CSVLoader gets auto selected based on file extension...
 const data = await loadFile('data.csv');
 ```
 

--- a/docs/api-reference/core/register-loaders.md
+++ b/docs/api-reference/core/register-loaders.md
@@ -1,0 +1,31 @@
+# Loader Registry
+
+The loader registry allows applications to cherry-pick which loaders to include in their application bundle by importing just the loaders they need and registering them during initialization.
+
+Applications can then make all those imported loaders available (via format autodetection) to all subsequent `parseFile` and `loadFile` calls, without those calls having to specify which loaders to use.
+
+## Usage
+
+Initialization imports and registers loaders:
+```js
+import {registerLoaders} from '@loaders.gl/core';
+import {CSVLoader} from '@loaders.gl/csv';
+
+registerLoaders(CSVLoader);
+```
+
+Some other file that needs to load CSV:
+```js
+import {loadFile} from '@loaders.gl/core';
+
+// The pre-registered SVLoader gets auto selected based on file extension...
+const data = await loadFile('data.csv');
+```
+
+## Functions
+
+### registerLoaders(loaders : Object | Object[])
+
+Registers one or more *loader objects* to a global *loader object registry*, these loaders will be used if no loader object is supplied to `parseFile` and `loadFile`.
+
+- `loaders` - can be a single loader or an array of loaders. The specified loaders will be added to any previously registered loaders.

--- a/modules/arrow/test/arrow-loader.spec.js
+++ b/modules/arrow/test/arrow-loader.spec.js
@@ -1,6 +1,7 @@
 import test from 'tape-promise/tape';
 import {isBrowser, readFile, loadFile} from '@loaders.gl/core';
-import {parseFileInBatches, parseFileInBatchesSync} from '@loaders.gl/core';
+import {parseFileInBatches} from '@loaders.gl/core';
+// import {parseFileInBatchesSync} from '@loaders.gl/core';
 import {ArrowLoader} from '@loaders.gl/arrow';
 import {ArrowWorkerLoader} from '@loaders.gl/arrow';
 import path from 'path';

--- a/modules/core/src/index.js
+++ b/modules/core/src/index.js
@@ -4,6 +4,7 @@ export {fetchFile, readFileSync} from './fetch-file/fetch-file';
 export {writeFile, writeFileSync} from './fetch-file/write-file';
 
 // FILE PARSING
+export {registerLoaders} from './parse-file/register-loaders';
 export {
   parseFile,
   parseFileSync,

--- a/modules/core/src/parse-file/parse-file.js
+++ b/modules/core/src/parse-file/parse-file.js
@@ -1,9 +1,19 @@
 import {autoDetectLoader} from './auto-detect-loader';
+import {getRegisteredLoaders} from './register-loaders';
 import {normalizeLoader, isLoaderObject} from './normalize-loader';
 import {parseWithLoader, parseWithLoaderInBatches, parseWithLoaderSync} from './parse-with-loader';
 import NullLog from '../log-utils/null-log';
 
 export async function parseFile(data, loaders, options, url) {
+  // Signature: parseFile(data, options, url)
+  // Uses registered loaders
+  if (!Array.isArray(loaders) && !isLoaderObject(loaders)) {
+    url = options;
+    options = loaders;
+    loaders = null;
+  }
+
+  loaders = loaders || getRegisteredLoaders();
   const loader = Array.isArray(loaders) ? autoDetectLoader(url, data, loaders) : loaders;
   normalizeLoader(loader);
 
@@ -14,7 +24,16 @@ export async function parseFile(data, loaders, options, url) {
 }
 
 export function parseFileSync(data, loaders, options, url) {
+  // Signature: parseFileSync(data, options, url)
+  // Uses registered loaders
+  if (!Array.isArray(loaders) && !isLoaderObject(loaders)) {
+    url = options;
+    options = loaders;
+    loaders = null;
+  }
+
   // Choose loader and normalize it
+  loaders = loaders || getRegisteredLoaders();
   const loader = Array.isArray(loaders) ? autoDetectLoader(url, data, loaders) : loaders;
   normalizeLoader(loader);
 
@@ -25,7 +44,16 @@ export function parseFileSync(data, loaders, options, url) {
 }
 
 export async function parseFileInBatches(data, loaders, options, url) {
+  // Signature: parseFileInBatches(data, options, url)
+  // Uses registered loaders
+  if (!Array.isArray(loaders) && !isLoaderObject(loaders)) {
+    url = options;
+    options = loaders;
+    loaders = null;
+  }
+
   // Choose loader and normalize it
+  loaders = loaders || getRegisteredLoaders();
   const loader = Array.isArray(loaders) ? autoDetectLoader(url, null, loaders) : loaders;
   normalizeLoader(loader);
 
@@ -36,7 +64,16 @@ export async function parseFileInBatches(data, loaders, options, url) {
 }
 
 export async function parseFileInBatchesSync(data, loaders, options, url) {
+  // Signature: parseFileInBatchesSync(data, options, url)
+  // Uses registered loaders
+  if (!Array.isArray(loaders) && !isLoaderObject(loaders)) {
+    url = options;
+    options = loaders;
+    loaders = null;
+  }
+
   // Choose loader and normalize it
+  loaders = loaders || getRegisteredLoaders();
   const loader = Array.isArray(loaders) ? autoDetectLoader(url, null, loaders) : loaders;
   normalizeLoader(loader);
 

--- a/modules/core/src/parse-file/register-loaders.js
+++ b/modules/core/src/parse-file/register-loaders.js
@@ -1,0 +1,12 @@
+import {normalizeLoader} from './normalize-loader';
+
+const registeredLoaders = [];
+
+export function registerLoaders(loaders) {
+  loaders = Array.isArray(loaders) ? loaders : [loaders];
+  registeredLoaders.push(loaders.map(loader => normalizeLoader(loader)));
+}
+
+export function getRegisteredLoaders() {
+  return registeredLoaders;
+}


### PR DESCRIPTION
A lot of doc changes creating noise so I copy the essential doc here

# Loader Registry

The loader registry allows applications to cherry-pick which loaders to include in their application bundle by importing just the loaders they need and registering them during initialization.

Applications can then make all those imported loaders available (via format autodetection) to all subsequent `parseFile` and `loadFile` calls, without those calls having to specify which loaders to use.

## Usage

Initialization imports and registers loaders:
```js
import {registerLoaders} from '@loaders.gl/core';
import {CSVLoader} from '@loaders.gl/csv';

registerLoaders(CSVLoader);
```

Some other file that needs to load CSV:
```js
import {loadFile} from '@loaders.gl/core';

// The pre-registered SVLoader gets auto selected based on file extension...
const data = await loadFile('data.csv');
```

## Functions

### registerLoaders(loaders : Object | Object[])

Registers one or more *loader objects* to a global *loader object registry*, these loaders will be used if no loader object is supplied to `parseFile` and `loadFile`.

- `loaders` - can be a single loader or an array of loaders. The specified loaders will be added to any previously registered loaders.