### PR TITLE
Fix broken GLB Parser getBuffer()

### DIFF
--- a/modules/gltf/src/glb/glb-parser.js
+++ b/modules/gltf/src/glb/glb-parser.js
@@ -98,10 +98,10 @@ export default class GLBParser {
 
     // Get the boundaries of the binary sub-chunk for this bufferView
     const glTFBufferView = this.json.bufferViews[glTFAccessor.bufferView];
-    assert(byteLength >= 0 && byteLength <= glTFBufferView.byteLength);
+    assert(byteLength >= 0 && glTFAccessor.byteOffset + byteLength <= glTFBufferView.byteLength);
 
-    const byteOffset = glTFBufferView.byteOffset + this.binaryByteOffset;
-    return new ArrayType(this.arrayBuffer, byteOffset, length);
+    const byteOffset = glTFBufferView.byteOffset + this.binaryByteOffset + glTFAccessor.byteOffset;
+    return new ArrayType(this.glbArrayBuffer, byteOffset, length);
   }
 
   // Unpacks an image into an HTML image


### PR DESCRIPTION
Fix referencing undefined this.arrayBuffer instead of this.glbArrayBuffer
Fix ignoring glTFAccessor.byteOffset

Was previously failing to load [Khronos Box sample](https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/Box).