### PR TITLE
Minor website fixes

### DIFF
--- a/website/ocular-config.js
+++ b/website/ocular-config.js
@@ -66,7 +66,24 @@ module.exports = {
     }
   ],
 
-  PROJECTS: [],
+  PROJECTS: [
+    {
+      name: 'deck.gl',
+      url: 'https://deck.gl'
+    },
+    {
+      name: 'luma.gl',
+      url: 'https://luma.gl'
+    },
+    {
+      name: 'react-map-gl',
+      url: 'https://uber.github.io/react-map-gl'
+    },
+    {
+      name: 'react-vis',
+      url: 'https://uber.github.io/react-vis'
+    }
+  ],
 
   ADDITIONAL_LINKS: [],
 

--- a/website/package.json
+++ b/website/package.json
@@ -37,7 +37,7 @@
     "gatsby-plugin-no-sourcemaps": "^2.0.2",
     "gatsby-plugin-styletron": "^3.0.5",
     "gh-pages": "^2.0.1",
-    "ocular-gatsby": "1.0.0-alpha.25",
+    "ocular-gatsby": "1.0.0-alpha.26",
     "sharp": "0.22.1"
   }
 }

--- a/website/src/components/site-query.jsx
+++ b/website/src/components/site-query.jsx
@@ -4,7 +4,7 @@
 
 // because this is a StaticQuery it needs to be in the local tree so that its graphQl can be
 // run by gatsby. Rather, a file of the same name must have the same query in the local tree.
-// During the init process, ocular copies this file over to the local tree. 
+// During the init process, ocular copies this file over to the local tree.
 
 
 import React from 'react';
@@ -18,6 +18,7 @@ const QUERY = graphql`
         PROJECT_NAME
         PROJECT_TYPE
         PROJECT_DESC
+        PROJECT_URL
         HOME_HEADING
         HOME_BULLETS {
           text


### PR DESCRIPTION
For #194 

- Upgrade to ocular-gatsby alpha.26 to fix getting started and github links
- Add list of sibling websites to ocular config to populate dropdown