### PR TITLE
3d-tiles: Tile3DHeader.loadContent() implemented

### DIFF
--- a/modules/3d-tiles/src/tile-3d-loader.js
+++ b/modules/3d-tiles/src/tile-3d-loader.js
@@ -6,10 +6,15 @@ export default {
   extensions: ['cmpt', 'pnts', 'b3dm', 'i3dm'],
   mimeType: 'application/octet-stream',
   parseSync,
+  parse,
   binary: true
 };
 
 function parseSync(arrayBuffer, options, url, loader) {
   const byteOffset = 0;
   return parse3DTileSync(arrayBuffer, byteOffset, options);
+}
+
+async function parse(arrayBuffer, options, url, loader) {
+  return parseSync(arrayBuffer, options, url, loader);
 }

--- a/modules/3d-tiles/src/tileset/tileset-3d.js
+++ b/modules/3d-tiles/src/tileset/tileset-3d.js
@@ -259,9 +259,8 @@ export default class Tileset3D {
     this._maximumMemoryUsage = value;
   }
 
-  // The root tile.
+  // The root tile header.
   get root() {
-    this._checkReady();
     return this._root;
   }
 
@@ -446,9 +445,5 @@ export default class Tileset3D {
       this.onTileUnload(tile);
       tile.unloadContent();
     });
-  }
-
-  _checkReady() {
-    assert(this.ready, '3D Tileset is not loaded. Wait for Tileset3D.ready to be true.');
   }
 }

--- a/modules/3d-tiles/src/tileset/tileset-3d.js
+++ b/modules/3d-tiles/src/tileset/tileset-3d.js
@@ -1,6 +1,7 @@
 import {Matrix4} from 'math.gl';
 import assert from '../utils/assert';
 import Tile3DHeader from './tile-3d-header';
+
 // import Tileset3DCache from './tileset-3d-cache';
 
 const Ellipsoid = {
@@ -51,7 +52,7 @@ const DEFAULT_OPTIONS = {
 
 function getBasePath(url) {
   const slashIndex = url && url.lastIndexOf('/');
-  return slashIndex >= 0 ? url.substr(0, slashIndex + 1) : '';
+  return slashIndex >= 0 ? url.substr(0, slashIndex) : '';
 }
 
 export default class Tileset3D {
@@ -235,6 +236,14 @@ export default class Tileset3D {
   } // eslint-disable-next-line
   // console.warn('Tileset3D.basePath is deprecated. Tiles are relative to the tileset JSON url');
 
+  get queryParams() {
+    const queryParams = [];
+    for (const key of Object.keys(this._queryParams)) {
+      queryParams.push(`${key}=${this._queryParams[key]}`);
+    }
+    return queryParams.length ? `?${queryParams.join('&')}` : '';
+  }
+
   // The maximum screen space error used to drive level of detail refinement.
   get maximumScreenSpaceError() {
     return this._maximumScreenSpaceError;
@@ -304,6 +313,10 @@ export default class Tileset3D {
     return this._extras;
   }
 
+  getTileUrl(tilePath) {
+    return `${this.basePath}/${tilePath}${this.queryParams}`;
+  }
+
   // true if the tileset JSON file lists the extension in extensionsUsed
   hasExtension(extensionName) {
     return Boolean(this._extensionsUsed && this._extensionsUsed.indexOf(extensionName) > -1);
@@ -322,10 +335,12 @@ export default class Tileset3D {
 
     // const statistics = this._statistics;
 
+    this._queryParams = {};
     if ('tilesetVersion' in asset) {
       // Append the tileset version to the resource
-      this._basePath += `?v=${asset.tilesetVersion}`;
+      this._queryParams.v = asset.tilesetVersion;
     } // eslint-disable-next-line
+
     // console.warn('Tileset3D.basePath is deprecated. Tiles are relative to the tileset JSON url');
 
     const resource = null;

--- a/modules/3d-tiles/test/tileset/tileset-3d.spec.js
+++ b/modules/3d-tiles/test/tileset/tileset-3d.spec.js
@@ -372,7 +372,7 @@ test('Tileset3D#handles failed tile processing', t => {
 });
 */
 
-test('Tileset3D#loades tiles in tileset', async t => {
+test('Tileset3D#loads tiles in tileset', async t => {
   const tilesetJson = await parse(fetchFile(TILESET_URL), Tileset3DLoader);
   const tileset = new Tileset3D(tilesetJson, TILESET_URL);
   await tileset.root.loadContent();

--- a/modules/3d-tiles/test/tileset/tileset-3d.spec.js
+++ b/modules/3d-tiles/test/tileset/tileset-3d.spec.js
@@ -370,16 +370,17 @@ test('Tileset3D#handles failed tile processing', t => {
   });
   t.end();
 });
+*/
 
-test('Tileset3D#renders tileset', t => {
-  const tileset = await loadTileset(scene, TILESET_URL);
-    const statistics = tileset._statistics;
-    t.equals(statistics.visited, 5);
-    t.equals(statistics.numberOfCommands, 5);
-  });
+test('Tileset3D#loades tiles in tileset', async t => {
+  const tilesetJson = await parse(fetchFile(TILESET_URL), Tileset3DLoader);
+  const tileset = new Tileset3D(tilesetJson, TILESET_URL);
+  await tileset.root.loadContent();
+  t.ok(tileset.root.content);
   t.end();
 });
 
+/*
 test('Tileset3D#does not render during morph', t => {
   const tileset = await loadTileset(scene, TILESET_URL);
     const commandList = scene.frameState.commandList;

--- a/modules/polyfills/src/fetch-node/fetch.node.js
+++ b/modules/polyfills/src/fetch-node/fetch.node.js
@@ -150,6 +150,10 @@ async function readFile(url, options = {}) {
     });
   }
 
+  // Remove any query parameters when loading from file
+  const queryIndex = url && url.lastIndexOf('?');
+  url = queryIndex >= 0 ? url.substr(0, queryIndex) : url;
+
   const readFileAsync = util.promisify(fs.readFile);
   const buffer = await readFileAsync(url, options);
   return buffer instanceof Buffer ? toArrayBuffer(buffer) : buffer;

--- a/test/modules.js
+++ b/test/modules.js
@@ -5,32 +5,32 @@ require('./aliases');
 require('@loaders.gl/polyfills');
 
 // Core
-require('@loaders.gl/polyfills/test');
-require('@loaders.gl/core/test');
-require('@loaders.gl/loader-utils/test');
-require('@loaders.gl/images/test');
+// require('@loaders.gl/polyfills/test');
+// require('@loaders.gl/core/test');
+// require('@loaders.gl/loader-utils/test');
+// require('@loaders.gl/images/test');
 
 // Pointcloud/Mesh Formats
-require('@loaders.gl/draco/test');
-require('@loaders.gl/las/test');
-require('@loaders.gl/obj/test');
-require('@loaders.gl/pcd/test');
-require('@loaders.gl/ply/test');
+// require('@loaders.gl/draco/test');
+// require('@loaders.gl/las/test');
+// require('@loaders.gl/obj/test');
+// require('@loaders.gl/pcd/test');
+// require('@loaders.gl/ply/test');
 
 // Scenegraph Formats
-require('@loaders.gl/gltf/test');
+// require('@loaders.gl/gltf/test');
 
 // 3D Tile Formats
 require('@loaders.gl/math/test');
 require('@loaders.gl/3d-tiles/test');
 
 // Geospatial Formats
-require('@loaders.gl/kml/test');
+// require('@loaders.gl/kml/test');
 
 // Table Formats
-require('@loaders.gl/arrow/test');
-require('@loaders.gl/csv/test');
-require('@loaders.gl/experimental/test');
+// require('@loaders.gl/arrow/test');
+// require('@loaders.gl/csv/test');
+// require('@loaders.gl/experimental/test');
 
 // Archive Formats
-require('@loaders.gl/zip/test');
+// require('@loaders.gl/zip/test');

--- a/test/modules.js
+++ b/test/modules.js
@@ -5,32 +5,32 @@ require('./aliases');
 require('@loaders.gl/polyfills');
 
 // Core
-// require('@loaders.gl/polyfills/test');
-// require('@loaders.gl/core/test');
-// require('@loaders.gl/loader-utils/test');
-// require('@loaders.gl/images/test');
+require('@loaders.gl/polyfills/test');
+require('@loaders.gl/core/test');
+require('@loaders.gl/loader-utils/test');
+require('@loaders.gl/images/test');
 
 // Pointcloud/Mesh Formats
-// require('@loaders.gl/draco/test');
-// require('@loaders.gl/las/test');
-// require('@loaders.gl/obj/test');
-// require('@loaders.gl/pcd/test');
-// require('@loaders.gl/ply/test');
+require('@loaders.gl/draco/test');
+require('@loaders.gl/las/test');
+require('@loaders.gl/obj/test');
+require('@loaders.gl/pcd/test');
+require('@loaders.gl/ply/test');
 
 // Scenegraph Formats
-// require('@loaders.gl/gltf/test');
+require('@loaders.gl/gltf/test');
 
 // 3D Tile Formats
 require('@loaders.gl/math/test');
 require('@loaders.gl/3d-tiles/test');
 
 // Geospatial Formats
-// require('@loaders.gl/kml/test');
+require('@loaders.gl/kml/test');
 
 // Table Formats
-// require('@loaders.gl/arrow/test');
-// require('@loaders.gl/csv/test');
-// require('@loaders.gl/experimental/test');
+require('@loaders.gl/arrow/test');
+require('@loaders.gl/csv/test');
+require('@loaders.gl/experimental/test');
 
 // Archive Formats
-// require('@loaders.gl/zip/test');
+require('@loaders.gl/zip/test');


### PR DESCRIPTION
Following test now passes:

```js
test('Tileset3D#loads tiles in tileset', async t => {
  const tilesetJson = await parse(fetchFile(TILESET_URL), Tileset3DLoader);
  const tileset = new Tileset3D(tilesetJson, TILESET_URL);
  await tileset.root.loadContent();
  t.ok(tileset.root.content);
  t.end();
});
```