### PR TITLE
Remove argument passed to TextEncoder that causes console.warn() to be called

### DIFF
--- a/modules/loader-utils/src/lib/binary-copy-utils.js
+++ b/modules/loader-utils/src/lib/binary-copy-utils.js
@@ -26,7 +26,7 @@ export function copyPaddedArrayBufferToDataView(dataView, byteOffset, sourceBuff
 }
 
 export function copyPaddedStringToDataView(dataView, byteOffset, string, padding) {
-  const textEncoder = new TextEncoder('utf8');
+  const textEncoder = new TextEncoder();
   // PERFORMANCE IDEA: We encode twice, once to get size and once to store
   // PERFORMANCE IDEA: Use TextEncoder.encodeInto() to avoid temporary copy
   const stringBuffer = textEncoder.encode(string);


### PR DESCRIPTION
The culprit for the `console.warn()`  is here:
 https://github.com/uber-web/loaders.gl/blob/master/modules/polyfills/src/text-encoding/encoding.js#L1125