### PR TITLE
arrow: Bump apache-arrow to 0.13. Use es5 dist for arrow to unblock Node 8.

### DIFF
--- a/examples/pointcloud/components/control-panel.js
+++ b/examples/pointcloud/components/control-panel.js
@@ -116,6 +116,7 @@ export default class ControlPanel extends PureComponent {
   _renderDropped() {
     // eslint-disable-next-line react/prop-types
     const {droppedFile} = this.props;
+    // eslint-disable-next-line react/prop-types
     return droppedFile ? <div>Dropped file: {JSON.stringify(droppedFile.name)}</div> : null;
   }
 

--- a/modules/arrow/package.json
+++ b/modules/arrow/package.json
@@ -35,6 +35,6 @@
   "dependencies": {
     "@loaders.gl/core": "1.1.0",
     "@loaders.gl/experimental": "1.1.0",
-    "apache-arrow": "^0.4.0"
+    "apache-arrow": "^0.13.0"
   }
 }

--- a/modules/arrow/src/lib/arrow-table-batch.js
+++ b/modules/arrow/src/lib/arrow-table-batch.js
@@ -1,4 +1,4 @@
-import {Schema, Field, RecordBatch, Float32Vector, Float32} from 'apache-arrow';
+import {Schema, Field, RecordBatch, Float32Vector, Float32} from 'apache-arrow/Arrow.es5.min';
 import {ColumnarTableBatch} from '@loaders.gl/experimental';
 
 export default class ArrowTableBatch extends ColumnarTableBatch {

--- a/modules/arrow/src/lib/parse-arrow-in-batches.js
+++ b/modules/arrow/src/lib/parse-arrow-in-batches.js
@@ -1,4 +1,4 @@
-import {RecordBatchReader} from 'apache-arrow';
+import {RecordBatchReader} from 'apache-arrow/Arrow.es5.min';
 import {isIterable, isIterator, assert} from '@loaders.gl/core';
 
 export async function parseArrowInBatches(asyncIterator, options) {

--- a/modules/arrow/src/lib/parse-arrow-sync.js
+++ b/modules/arrow/src/lib/parse-arrow-sync.js
@@ -1,4 +1,4 @@
-import {Table} from 'apache-arrow';
+import {Table} from 'apache-arrow/Arrow.es5.min';
 
 // Parses arrow to a columnar table
 export default function parseArrowSync(arrayBuffer, options) {

--- a/modules/csv/test/csv-loader-arrow.spec.js
+++ b/modules/csv/test/csv-loader-arrow.spec.js
@@ -2,7 +2,7 @@ import test from 'tape-promise/tape';
 import {loadInBatches, isIterator, isAsyncIterable} from '@loaders.gl/core';
 import {CSVLoader} from '@loaders.gl/csv';
 import {ArrowTableBatch} from '@loaders.gl/arrow';
-import {RecordBatch} from 'apache-arrow';
+import {RecordBatch} from 'apache-arrow/Arrow.es5.min';
 // import {Schema, Field, RecordBatch, Float32Vector} from 'apache-arrow';
 
 // Small CSV Sample Files

--- a/yarn.lock
+++ b/yarn.lock
@@ -1842,10 +1842,10 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
-apache-arrow@^0.4.0:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/apache-arrow/-/apache-arrow-0.4.1.tgz#1a8fffb242061108ed7f753eb9971e593864647e"
-  integrity sha512-zjST/y1CjUb7StvrEqKoziZkRj43hfTKT21yhIoo9ECCPuRsql5PlTFCgpvYcdZMXdnI0dmO8E+yBErUtieXPw==
+apache-arrow@^0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/apache-arrow/-/apache-arrow-0.13.0.tgz#08b16aca0d6159539f1c7e2d9ccb5e43c76d50cd"
+  integrity sha512-+RlJzbOLFdegb76e39QJJsX1DtIzqJXJpsuQh3xmsjwU6ksnEyGI9WolO78yHz8akaJ8BFNC8A8MgEmc1O6FFw==
   dependencies:
     "@types/flatbuffers" "^1.9.0"
     "@types/node" "^10.12.18"


### PR DESCRIPTION
@trxcllnt Looks like we need to explicitly import the es5 dist to get apache-arrow working on Node 8, is that expected?