### PR TITLE
3d-tiles: Fix traversal issues

### DIFF
--- a/examples/3d-tiles/tile-3d-layer.js
+++ b/examples/3d-tiles/tile-3d-layer.js
@@ -329,7 +329,7 @@ export default class Tile3DLayer extends CompositeLayer {
       if (!coordinateOrigin) {
         if (modelMatrix) {
           const origin = new Vector3();
-          modelMatrix.transformVector3([0, 0, 0], origin);
+          modelMatrix.transform(origin, origin);
           transformProps.coordinateOrigin = Ellipsoid.WGS84.cartesianToCartographic(origin, origin);
           modelMatrix = null;
         } else {

--- a/examples/3d-tiles/tile-3d-layer.js
+++ b/examples/3d-tiles/tile-3d-layer.js
@@ -53,6 +53,7 @@ export default class Tile3DLayer extends CompositeLayer {
       tileset3d = new Tileset3D(tilesetJson, tilesetUrl, options);
 
       // TODO: Remove these after sse traversal is working since this is just to prevent full load of tileset and loading of root
+      // The alwaysLoadRoot is better solved by moving the camera to the newly selected asset.
       tileset3d.depthLimit = this.props.depthLimit;
       tileset3d.alwaysLoadRoot = true;
     }
@@ -127,21 +128,20 @@ export default class Tile3DLayer extends CompositeLayer {
 
     for (const value of layerMapValues) {
       const {tile} = value;
-      let {layer} = value;
+      const {layer} = value;
 
       if (tile.selectedFrame === frameNumber) {
         if (!layer.props.visible) {
-          layer = layer.clone({visible: true});
-          layerMap[tile.contentUri].layer = layer;
+          // Still has GPU resource but visibilty is turned off so turn it back on so we can render it.
+          layerMap[tile.contentUri].layer = layer.clone({visible: true});
         }
         selectedLayers.push(layer);
       } else if (tile.contentUnloaded) {
         // Was cleaned up from tileset cache. We no longer need to track it.
         layerMap.delete(tile.contentUri);
       } else if (layer.props.visible) {
-        // Still in tileset cache but doesn't need to render this frame, keep the GPU resource bound but don't render it.
-        layer = layer.clone({visible: false});
-        layerMap[tile.contentUri].layer = layer;
+        // Still in tileset cache but doesn't need to render this frame. Keep the GPU resource bound but don't render it.
+        layerMap[tile.contentUri].layer = layer.clone({visible: false});
       }
     }
 

--- a/modules/3d-tiles/src/tileset/tileset-3d-traverser.js
+++ b/modules/3d-tiles/src/tileset/tileset-3d-traverser.js
@@ -34,7 +34,7 @@ export default class Tileset3DTraverser {
     }
 
     // The this doesn't meet the SSE requirement, therefore the tree does not need to be rendered
-    // TODO: remove the alwaysLoadRoot after sse working
+    // The alwaysLoadRoot is better solved by moving the camera to the newly selected asset.
     if (
       !tileset.alwaysLoadRoot &&
       root.getScreenSpaceError(frameState, true) <= tileset.maximumScreenSpaceError

--- a/modules/3d-tiles/src/tileset/tileset-3d-traverser.js
+++ b/modules/3d-tiles/src/tileset/tileset-3d-traverser.js
@@ -34,7 +34,11 @@ export default class Tileset3DTraverser {
     }
 
     // The this doesn't meet the SSE requirement, therefore the tree does not need to be rendered
-    if (root.getScreenSpaceError(frameState, true) <= tileset.maximumScreenSpaceError) {
+    // TODO: remove the alwaysLoadRoot after sse working
+    if (
+      !tileset.alwaysLoadRoot &&
+      root.getScreenSpaceError(frameState, true) <= tileset.maximumScreenSpaceError
+    ) {
       return false;
     }
 


### PR DESCRIPTION
Fixed issue with loading roots. Roots are culled if they are too far away from camera. The fix is hacky and the better solution is moving the camera to the newly selected asset from the dropdown menu.
Fixed issue with Matrix4 api call to include the output parameter since that one worked.
Fixed issue where layer.visible was moved to layer.props.visible.