### PR TITLE
Camera focus on asset change

### DIFF
--- a/modules/3d-tiles/src/tileset/helpers/bounding-volume.js
+++ b/modules/3d-tiles/src/tileset/helpers/bounding-volume.js
@@ -30,9 +30,9 @@ export function createBoundingVolume(boundingVolumeHeader, transform, result) {
   if (boundingVolumeHeader.box) {
     // The first three elements define the x, y, and z values for the center of the box.
     const [x, y, z] = boundingVolumeHeader.box;
-    let center = new Vector3(x, y, z);
-    center = new Matrix4(transform).transform(center);
-    center = Ellipsoid.WGS84.cartesianToCartographic(center, center);
+    const center = new Vector3(x, y, z);
+    transform.transform(center, center);
+    Ellipsoid.WGS84.cartesianToCartographic(center, center);
 
     Object.assign(result, boundingVolumeHeader, {center});
 
@@ -58,10 +58,9 @@ export function createBoundingVolume(boundingVolumeHeader, transform, result) {
   if (boundingVolumeHeader.sphere) {
     // The first three elements define the x, y, and z values for the center of the sphere in a right-handed 3-axis (x, y, z)
     const [x, y, z] = boundingVolumeHeader.sphere;
-    let center = new Vector3(x, y, z);
-
-    center = new Matrix4(transform).transform(center);
-    center = Ellipsoid.WGS84.cartesianToCartographic(center, center);
+    const center = new Vector3(x, y, z);
+    transform.transform(center, center);
+    Ellipsoid.WGS84.cartesianToCartographic(center, center);
 
     Object.assign(result, boundingVolumeHeader, {center});
 


### PR DESCRIPTION
Allows camera to re-focus on asset change. Due to some issue with the non-output parameter version of `transform` center was undefined.