### PR TITLE
3d-tiles: Convert camera parameters to WGS84 cartesian

### DIFF
--- a/examples/3d-tiles/tile-3d-layer.js
+++ b/examples/3d-tiles/tile-3d-layer.js
@@ -120,7 +120,10 @@ export default class Tile3DLayer extends CompositeLayer {
     const viewportCenterCartographic = [viewport.longitude, viewport.latitude, 0];
     // TODO - Ellipsoid.eastNorthUpToFixedFrame() breaks on raw array, create a Vector.
     // TODO - Ellipsoid.eastNorthUpToFixedFrame() takes a cartesian, is that intuitive?
-    const viewportCenterCartesian = Ellipsoid.WGS84.cartographicToCartesian(viewportCenterCartographic, new Vector3());
+    const viewportCenterCartesian = Ellipsoid.WGS84.cartographicToCartesian(
+      viewportCenterCartographic,
+      new Vector3()
+    );
     const enuToFixedTransform = Ellipsoid.WGS84.eastNorthUpToFixedFrame(viewportCenterCartesian);
 
     const cameraPositionCartesian = enuToFixedTransform.transform(cameraPositionENU);

--- a/modules/3d-tiles/src/tileset/tileset-3d.js
+++ b/modules/3d-tiles/src/tileset/tileset-3d.js
@@ -8,6 +8,7 @@ import Tileset3DTraverser from './tileset-3d-traverser';
 
 // import Tileset3DCache from './tileset-3d-cache';
 
+// TODO - hack - fix or remove. Do we need a configurable Ellipsoid?
 const Ellipsoid = {
   WGS84: ''
 };


### PR DESCRIPTION
@loshjawrence Attempt to convert `cameraPosition, cameraDirection, cameraUp` to WGS84 cartesian coordinates.