### PR TITLE
Cleanup old tile._content

### DIFF
--- a/examples/3d-tiles/tile-3d-layer.js
+++ b/examples/3d-tiles/tile-3d-layer.js
@@ -147,7 +147,7 @@ export default class Tile3DLayer extends CompositeLayer {
         up: cameraUpCartesian
       },
       height,
-      frameNumber: tick,
+      frameNumber: tick, // TODO: This can be the same between updates, what number is unique for between updates?
       sseDenominator: 1.15 // Assumes fovy = 60 degrees
     };
 
@@ -176,7 +176,7 @@ export default class Tile3DLayer extends CompositeLayer {
         selectedLayers.push(layer);
       } else if (tile.contentUnloaded) {
         // Was cleaned up from tileset cache. We no longer need to track it.
-        layerMap.delete(tile.contentUri);
+        delete layerMap[tile.contentUri];
       } else if (layer.props.visible) {
         // Still in tileset cache but doesn't need to render this frame. Keep the GPU resource bound but don't render it.
         layer = layer.clone({visible: false});
@@ -200,6 +200,8 @@ export default class Tile3DLayer extends CompositeLayer {
       this._unpackTile(tile);
 
       const layer = this._render3DTileLayer(tile);
+
+      tileset3d.addTileToCache(tile); // Add and remove on main thread
 
       layerMap[tile.contentUri] = {
         layer,

--- a/modules/3d-tiles/src/tileset/tile-3d-header.js
+++ b/modules/3d-tiles/src/tileset/tile-3d-header.js
@@ -107,7 +107,7 @@ export default class Tile3DHeader {
     return this._contentState === TILE3D_CONTENT_STATE.READY;
   }
 
-  // Returns true if tile is an empty tile or an external tileset
+  // Returns true if tile is not an empty tile and not an external tileset
   get hasRenderContent() {
     return !this.hasEmptyContent && !this.hasTilesetContent;
   }
@@ -292,7 +292,7 @@ export default class Tile3DHeader {
 
   // Unloads the tile's content.
   unloadContent() {
-    if (this.hasRenderContent) {
+    if (!this.hasRenderContent) {
       return;
     }
 

--- a/modules/3d-tiles/src/tileset/tile-3d-header.js
+++ b/modules/3d-tiles/src/tileset/tile-3d-header.js
@@ -28,9 +28,11 @@ export default class Tile3DHeader {
 
     this._tileset = tileset;
     this._header = header;
+    this.cacheNode = undefined;
 
     this._content = null;
     this._contentState = TILE3D_CONTENT_STATE.UNLOADED;
+    this._gpuMemoryUsageInBytes = 0;
 
     // Gets the tile's children.
     this.children = [];
@@ -74,6 +76,11 @@ export default class Tile3DHeader {
 
   isDestroyed() {
     return this._header === null;
+  }
+
+  // The tileset containing this tile.
+  get gpuMemoryUsageInBytes() {
+    return this._gpuMemoryUsageInBytes;
   }
 
   // The tileset containing this tile.
@@ -599,7 +606,14 @@ export default class Tile3DHeader {
     // The content may be tileset json
     if (this._isTileset(this._content)) {
       this.hasTilesetContent = true;
+    } else {
+      this._updateGPUMemoryUsageInBytes();
     }
+  }
+
+  _updateGPUMemoryUsageInBytes() {
+    // Good enough? Didn't look too deep but it seemed like it already had the buffers' byte lengths.
+    this._gpuMemoryUsageInBytes = this._content.byteLength;
   }
 
   // Update the tile's transform. The transform is applied to the tile's bounding volumes.

--- a/modules/3d-tiles/src/tileset/tileset-3d-cache.js
+++ b/modules/3d-tiles/src/tileset/tileset-3d-cache.js
@@ -47,7 +47,7 @@ export default class Tileset3DCache {
     this._list.remove(node);
     tile.cacheNode = undefined;
     if (unloadCallback) {
-      unloadCallback(tileset, tile);
+      unloadCallback(tile);
     }
   }
 

--- a/modules/3d-tiles/src/tileset/tileset-3d-cache.js
+++ b/modules/3d-tiles/src/tileset/tileset-3d-cache.js
@@ -1,6 +1,7 @@
 // This file is derived from the Cesium code base under Apache 2 license
 // See LICENSE.md and https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md
 
+import DoublyLinkedList from '../utils/doubly-linked-list';
 const defined = x => x !== undefined;
 
 /**
@@ -12,7 +13,7 @@ export default class Tileset3DCache {
   constructor() {
     // [head, sentinel) -> tiles that weren't selected this frame and may be removed from the cache
     // (sentinel, tail] -> tiles that were selected this frame
-    this._list = []; // new DoublyLinkedList();
+    this._list = new DoublyLinkedList();
     this._sentinel = this._list.add();
     this._trimTiles = false;
   }

--- a/modules/3d-tiles/src/tileset/tileset-3d-traverser.js
+++ b/modules/3d-tiles/src/tileset/tileset-3d-traverser.js
@@ -95,10 +95,12 @@ export default class Tileset3DTraverser {
   }
 
   touchTile(tileset, tile, frameState) {
-    if (tile._touchedFrame === frameState.frameNumber) {
-      // Prevents another pass from touching the frame again
-      return;
-    }
+    // TODO need a better frameNumber since it can be the same between updates
+    // Until then this needs to be commented out
+    // if (tile._touchedFrame === frameState.frameNumber) {
+    //   // Prevents another pass from touching the frame again
+    //   return;
+    // }
     tileset._cache.touch(tile);
     tile._touchedFrame = frameState.frameNumber;
   }
@@ -326,7 +328,7 @@ export default class Tileset3DTraverser {
       }
 
       // this.visitTile(tileset, tile, frameState);
-      // this.touchTile(tileset, tile, frameState);
+      this.touchTile(tileset, tile, frameState);
       tile._refines = refines;
     }
   }

--- a/modules/3d-tiles/src/tileset/tileset-3d.js
+++ b/modules/3d-tiles/src/tileset/tileset-3d.js
@@ -6,7 +6,7 @@ import assert from '../utils/assert';
 import Tile3DHeader from './tile-3d-header';
 import Tileset3DTraverser from './tileset-3d-traverser';
 
-// import Tileset3DCache from './tileset-3d-cache';
+import Tileset3DCache from './tileset-3d-cache';
 
 const Ellipsoid = {
   WGS84: ''
@@ -83,7 +83,7 @@ export default class Tileset3D {
     this._gltfUpAxis = undefined;
     this._traverser = new Tileset3DTraverser();
 
-    // this._cache = new Tileset3DCache();
+    this._cache = new Tileset3DCache();
     this._processingQueue = [];
     this.selectedTiles = [];
     this._emptyTiles = [];

--- a/modules/3d-tiles/src/tileset/tileset-3d.js
+++ b/modules/3d-tiles/src/tileset/tileset-3d.js
@@ -430,6 +430,7 @@ export default class Tileset3D {
     for (const tile of requestedTiles) {
       this._requestContent(tile);
     }
+    this._cache.unloadTiles(this, tile => tile.unloadContent());
   }
 
   async _requestContent(tile) {
@@ -447,11 +448,10 @@ export default class Tileset3D {
     }
 
     try {
-      // await tile.contentReadyPromise;
-      // if (!tile.hasTilesetContent) {
-      //   // Add to the tile cache. Previously expired tiles are already in the cache and won't get re-added.
-      //   this._cache.add(tile);
-      // }
+      if (tile.hasRenderContent) {
+        // Add to the tile cache. Previously expired tiles are already in the cache and won't get re-added.
+        this._cache.add(tile);
+      }
 
       this.onTileLoad(tile);
     } catch (error) {

--- a/modules/3d-tiles/src/tileset/tileset-3d.js
+++ b/modules/3d-tiles/src/tileset/tileset-3d.js
@@ -156,6 +156,8 @@ export default class Tileset3D {
     this._skipLevelOfDetail = this.skipLevelOfDetail;
     this._disableSkipLevelOfDetail = false;
 
+    this._gpuMemoryUsageInBytes = 0;
+
     this.initializeTileSet(json, options);
 
     this.props = {};
@@ -329,8 +331,8 @@ export default class Tileset3D {
   // The total amount of GPU memory in bytes used by the tileset. This value is estimated from
   // geometry, texture, and batch table textures of loaded tiles. For point clouds, this value also
   // includes per-point metadata.
-  get totalMemoryUsageInBytes() {
-    return 0;
+  get gpuMemoryUsageInBytes() {
+    return this._gpuMemoryUsageInBytes;
     // const statistics = this._statistics;
     // return statistics.texturesByteLength + statistics.geometryByteLength + statistics.batchTableByteLength;
   }
@@ -419,8 +421,23 @@ export default class Tileset3D {
     this._cache.trim();
   }
 
+  decrementGPUMemoryUsage(bytes) {
+    this._gpuMemoryUsageInBytes -= bytes;
+  }
+
+  incrementGPUMemoryUsage(bytes) {
+    this._gpuMemoryUsageInBytes += bytes;
+  }
+
+  addTileToCache(tile) {
+    // Add to the tile cache. Previously expired tiles are already in the cache and won't get re-added.
+    this._cache.add(tile);
+  }
+
   update(frameState) {
     this._updatedVisibilityFrame++; // TODO: only update when camera or culling volume from last update moves (could be render camera change or prefetch camera)
+    this._cache.reset();
+
     this._traverser.traverse(this, frameState);
 
     const requestedTiles = this._requestedTiles;
@@ -430,7 +447,7 @@ export default class Tileset3D {
     for (const tile of requestedTiles) {
       this._requestContent(tile);
     }
-    this._cache.unloadTiles(this, tile => tile.unloadContent());
+    this._cache.unloadTiles(this);
   }
 
   async _requestContent(tile) {
@@ -448,11 +465,6 @@ export default class Tileset3D {
     }
 
     try {
-      if (tile.hasRenderContent) {
-        // Add to the tile cache. Previously expired tiles are already in the cache and won't get re-added.
-        this._cache.add(tile);
-      }
-
       this.onTileLoad(tile);
     } catch (error) {
       this.onTileLoadFailed({

--- a/modules/3d-tiles/src/utils/doubly-linked-list-node.js
+++ b/modules/3d-tiles/src/utils/doubly-linked-list-node.js
@@ -1,0 +1,17 @@
+// This file is derived from the Cesium code base under Apache 2 license
+// See LICENSE.md and https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md
+
+const defined = x => x !== undefined;
+
+/**
+ * Doubly linked list node
+ *
+ * @private
+ */
+export default class DoublyLinkedListNode {
+  constructor(item, previous, next) {
+      this.item = item;
+      this.previous  = previous;
+      this.next = next;
+  }
+}

--- a/modules/3d-tiles/src/utils/doubly-linked-list-node.js
+++ b/modules/3d-tiles/src/utils/doubly-linked-list-node.js
@@ -1,8 +1,6 @@
 // This file is derived from the Cesium code base under Apache 2 license
 // See LICENSE.md and https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md
 
-const defined = x => x !== undefined;
-
 /**
  * Doubly linked list node
  *
@@ -10,8 +8,8 @@ const defined = x => x !== undefined;
  */
 export default class DoublyLinkedListNode {
   constructor(item, previous, next) {
-      this.item = item;
-      this.previous  = previous;
-      this.next = next;
+    this.item = item;
+    this.previous = previous;
+    this.next = next;
   }
 }

--- a/modules/3d-tiles/src/utils/doubly-linked-list.js
+++ b/modules/3d-tiles/src/utils/doubly-linked-list.js
@@ -1,0 +1,103 @@
+// This file is derived from the Cesium code base under Apache 2 license
+// See LICENSE.md and https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md
+
+import DoublyLinkedListNode from '../utils/doubly-linked-list-node';
+
+const defined = x => x !== undefined;
+
+/**
+ * Doubly linked list
+ *
+ * @private
+ */
+export default class DoublyLinkedList {
+  constructor() {
+    this.head = undefined;
+    this.tail = undefined;
+    this._length = 0;
+  }
+
+  get length() {
+    return this._length;
+  }
+
+  /**
+   * Adds the item to the end of the list
+   * @param {*} [item]
+   * @return {DoublyLinkedListNode}
+   */
+  add(item) {
+    const node = new DoublyLinkedListNode(item, this.tail, undefined);
+
+    if (defined(this.tail)) {
+      this.tail.next = node;
+      this.tail = node;
+    } else {
+      this.head = node;
+      this.tail = node;
+    }
+
+    ++this._length;
+
+    return node;
+  }
+
+  /**
+   * Removes the given node from the list
+   * @param {DoublyLinkedListNode} node
+   */
+  remove(node) {
+    if (!defined(node)) {
+      return;
+    }
+
+    if (defined(node.previous) && defined(node.next)) {
+      node.previous.next = node.next;
+      node.next.previous = node.previous;
+    } else if (defined(node.previous)) {
+      // Remove last node
+      node.previous.next = undefined;
+      this.tail = node.previous;
+    } else if (defined(node.next)) {
+      // Remove first node
+      node.next.previous = undefined;
+      this.head = node.next;
+    } else {
+      // Remove last node in the linked list
+      this.head = undefined;
+      this.tail = undefined;
+    }
+
+    node.next = undefined;
+    node.previous = undefined;
+
+    --this._length;
+  }
+
+  /**
+   * Moves nextNode after node
+   * @param {DoublyLinkedListNode} node
+   * @param {DoublyLinkedListNode} nextNode
+   */
+  splice(node, nextNode) {
+    if (node === nextNode) {
+      return;
+    }
+
+    // Remove nextNode, then insert after node
+    this.remove(nextNode);
+
+    const oldNodeNext = node.next;
+    node.next = nextNode;
+
+    // Tail check
+    if (this.tail === node) {
+      this.tail = nextNode;
+    } else {
+      oldNodeNext.previous = nextNode;
+    }
+
+    nextNode.next = oldNodeNext;
+    nextNode.previous = node;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1484,23 +1484,23 @@
     "@luma.gl/webgl2-polyfill" "7.1.1"
     probe.gl "^3.0.2"
 
-"@math.gl/culling@^3.0.0-alpha.5":
-  version "3.0.0-alpha.6"
-  resolved "https://registry.yarnpkg.com/@math.gl/culling/-/culling-3.0.0-alpha.6.tgz#19937e5ece51e82617ad0de7caa650c2e01a484c"
-  integrity sha512-66MLEsqJOqDJJz82XIXnpyQ4NugwciMBV6IwvMQL2aTcEmOY7HHRYq2RR7OiPuMGcvCf8LND3+oqIV3eTq0qng==
+"@math.gl/culling@^3.0.0-alpha.6":
+  version "3.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@math.gl/culling/-/culling-3.0.0-beta.1.tgz#35b66a5834630693971338eaf591647f748640b9"
+  integrity sha512-KdOf5ey6b9C9enPY5nAhBAb97Oyauu0APTRrV3bZ2YalR7RxVlgVD3ONSp0SOFrjclI758uvXLQ/MKDnBsvbqA==
   dependencies:
     "@babel/runtime" "^7.0.0"
     gl-matrix "^3.0.0"
-    math.gl "3.0.0-alpha.6"
+    math.gl "3.0.0-beta.1"
 
-"@math.gl/geospatial@^3.0.0-alpha.5":
-  version "3.0.0-alpha.6"
-  resolved "https://registry.yarnpkg.com/@math.gl/geospatial/-/geospatial-3.0.0-alpha.6.tgz#d1d82ebd59eedfaa1d1064ab32f298ed1317a4db"
-  integrity sha512-1aQKrf6wT1trxMNmWHI/80WKET4IZf1T3W9KJjwwEl0ZQ0Tk5G0ontASJOftSVagPwe51Ybl2aMO1xM3Dex/ow==
+"@math.gl/geospatial@^3.0.0-alpha.6":
+  version "3.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@math.gl/geospatial/-/geospatial-3.0.0-beta.1.tgz#030de50f32f7cf00d6e73c6bd923ecbffca84b25"
+  integrity sha512-AWNqJP+GfNmTEPBHnWc2f9vTzx3Ig1C5YTBFNTFP0mKBbdOXHaCMNemWm36Oo9gpRfVgQquXWumvZ0+eqgwpbg==
   dependencies:
     "@babel/runtime" "^7.0.0"
     gl-matrix "^3.0.0"
-    math.gl "3.0.0-alpha.6"
+    math.gl "3.0.0-beta.1"
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
@@ -6054,10 +6054,10 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-math.gl@3.0.0-alpha.6, math.gl@^3.0.0-alpha.5:
-  version "3.0.0-alpha.6"
-  resolved "https://registry.yarnpkg.com/math.gl/-/math.gl-3.0.0-alpha.6.tgz#ee49665dafa0e622d6c8867cefcfcc7e049108d2"
-  integrity sha512-7guDwZS5FIF1u9he6nb9mu2IR+hI13AZY141aJRVBmCykaigS9BIxUQyBoqINa/+cCacONf+QtSh/fLTFP1JXg==
+math.gl@3.0.0-beta.1, math.gl@^3.0.0-alpha.6:
+  version "3.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/math.gl/-/math.gl-3.0.0-beta.1.tgz#9e476e8be0ab672406ac4c2441bfa742440129d8"
+  integrity sha512-MPOpGxicDPmHHzjTaQl4iokGORiqP7KkLIxZ6e0IBKwENHkNvx9ak8BXWWSZe4qoyAOu7qvEsCUDk3wccUzK/g==
   dependencies:
     "@babel/runtime" "^7.0.0"
     gl-matrix "^3.0.0"


### PR DESCRIPTION
Adds a tileset3d cache to clean up _content from tiles that weren't traversed this frame. These unloaded tiles are removed from the layer map.

Tested with a budget of 1MB on st helens to trigger the codes paths make sure things behaved as expected.

This is port of the cesium impl.