### PR TITLE
Add options to ImageBitmapLoader

### DIFF
--- a/docs/api-reference/image-loaders/image-loader.md
+++ b/docs/api-reference/image-loaders/image-loader.md
@@ -2,10 +2,19 @@
 
 An image loader that works under both Node.js and the browser.
 
+```js
+import '@loaders.gl/polyfill';  // if using under Node
+import {ImageLoader} from '@loaders.gl/images';
+import {load} from '@loaders.gl/core';
+
+load(url, ImageLoader, options);
+```
+
 ## Options
 
-- `image`
-- `options.mimeType`
+- `crossOrigin` - passed to [Image.crossorigin](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img). Only used if in browser main thread.
+- `imageOrientation` - passed to [createImageBitmap](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/createImageBitmap). Only used if in webworker.
+- `premultiplyAlpha` - passed to [createImageBitmap](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/createImageBitmap). Only used if in webworker.
 
 ## Remarks
 

--- a/modules/images/src/image-loader.js
+++ b/modules/images/src/image-loader.js
@@ -21,7 +21,10 @@ export default {
 // Specifically loads an ImageBitmap (works on newer browsers, on both main and worker threads)
 export const ImageBitmapLoader = {
   extensions: EXTENSIONS,
-  parse: parseToImageBitmap
+  parse: parseToImageBitmap,
+  defaultOptions: {
+    imageOrientation: 'flipY' // for WebGL texture use case
+  }
 };
 
 // Specifically loads an HTMLImage (works on all browsers' main thread but not on worker threads)

--- a/modules/images/src/image-loader.js
+++ b/modules/images/src/image-loader.js
@@ -21,10 +21,7 @@ export default {
 // Specifically loads an ImageBitmap (works on newer browsers, on both main and worker threads)
 export const ImageBitmapLoader = {
   extensions: EXTENSIONS,
-  parse: parseToImageBitmap,
-  defaultOptions: {
-    imageOrientation: 'flipY' // for WebGL texture use case
-  }
+  parse: parseToImageBitmap
 };
 
 // Specifically loads an HTMLImage (works on all browsers' main thread but not on worker threads)

--- a/modules/images/src/lib/parse-image.js
+++ b/modules/images/src/lib/parse-image.js
@@ -11,7 +11,7 @@ export function parseImage(arrayBuffer, options) {
     return global._parseImageNode(arrayBuffer, mimeType, options);
   }
 
-  return parseToImageBitmap(arrayBuffer);
+  return parseToImageBitmap(arrayBuffer, options);
 }
 
 // Fallback for older browsers
@@ -21,7 +21,7 @@ export async function loadImage(url, options) {
   if (typeof Image === 'undefined') {
     const response = await fetch(url, options);
     const arrayBuffer = await response.arrayBuffer();
-    return parseImage(arrayBuffer);
+    return parseImage(arrayBuffer, options);
   }
   return await loadToHTMLImage(url, options);
 }
@@ -36,7 +36,10 @@ export function parseToImageBitmap(arrayBuffer, options) {
   }
 
   const blob = new Blob([new Uint8Array(arrayBuffer)]);
-  return createImageBitmap(blob, options);
+  return createImageBitmap(blob, {
+    imageOrientation: options.imageOrientation || 'none',
+    premultiplyAlpha: options.premultiplyAlpha || 'default'
+  });
 }
 
 //

--- a/modules/images/src/lib/parse-image.js
+++ b/modules/images/src/lib/parse-image.js
@@ -30,13 +30,13 @@ export async function loadImage(url, options) {
 // Supported on worker threads
 // Not supported on Edge and Safari
 // https://developer.mozilla.org/en-US/docs/Web/API/ImageBitmap#Browser_compatibility
-export function parseToImageBitmap(arrayBuffer) {
+export function parseToImageBitmap(arrayBuffer, options) {
   if (typeof createImageBitmap === 'undefined') {
     throw new Error('parseImage');
   }
 
   const blob = new Blob([new Uint8Array(arrayBuffer)]);
-  return createImageBitmap(blob);
+  return createImageBitmap(blob, options);
 }
 
 //

--- a/modules/images/src/lib/parse-image.js
+++ b/modules/images/src/lib/parse-image.js
@@ -17,7 +17,7 @@ export function parseImage(arrayBuffer, options) {
 // Fallback for older browsers
 // TODO - investigate Image.decode()
 // https://medium.com/dailyjs/image-loading-with-image-decode-b03652e7d2d2
-export async function loadImage(url, options) {
+export async function loadImage(url, options = {}) {
   if (typeof Image === 'undefined') {
     const response = await fetch(url, options);
     const arrayBuffer = await response.arrayBuffer();


### PR DESCRIPTION
Right now the loaded ImageBitmap is flipped if used with `Texture`.