### PR TITLE
Fix babel config for already transpiled files

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -11,18 +11,22 @@ module.exports = api => {
     }
   ]);
 
-  // config.ignore = ['**/*.worker.js', '**/*.transpiled.js', '**/*.min.js'];
-  config.ignore = ['**/*.worker.js'];
-
+  // https://babeljs.io/docs/en/options#overrides
+  const overrides = config.overrides || [];
   // TEST to prevent compilation of already transpiled files
-  config.overrides = config.overrides || [];
-  config.overrides.push({
-    // Tell babel these are already large and minified
-    // https://babeljs.io/docs/en/options#overrides
+  // These files should be copied without any modification
+  overrides.push({
     test: /min.js|transpiled.js/,
     compact: false,
     sourceMaps: false
   });
+  // Default babel config (env, plugin) only apply to the rest of the files
+  overrides.push(Object.assign({
+    exclude: /min.js|transpiled.js/,
+  }, config));
 
-  return config;
+  return {
+    ignore: ['**/*.worker.js'],
+    overrides
+  };
 };

--- a/babel.config.js
+++ b/babel.config.js
@@ -21,9 +21,14 @@ module.exports = api => {
     sourceMaps: false
   });
   // Default babel config (env, plugin) only apply to the rest of the files
-  overrides.push(Object.assign({
-    exclude: /min.js|transpiled.js/,
-  }, config));
+  overrides.push(
+    Object.assign(
+      {
+        exclude: /min.js|transpiled.js/
+      },
+      config
+    )
+  );
 
   return {
     ignore: ['**/*.worker.js'],

--- a/modules/csv/src/papaparse/papaparse.transpiled.js
+++ b/modules/csv/src/papaparse/papaparse.transpiled.js
@@ -33,9 +33,9 @@ var global = (function() {
   return {};
 })();
 
-const IS_PAPA_WORKER = false;
+var IS_PAPA_WORKER = false;
 
-const Papa = {};
+var Papa = {};
 module.exports = Papa;
 Papa.parse = CsvToJson;
 Papa.unparse = JsonToCsv;


### PR DESCRIPTION
Babel's root `env` and `plugins` config are *merged* with `overrides`. The transpiled files end up still being transpiled. This breaks the current las module because the output mixes `import` and `module.exports`.