### PR TITLE
Add additional check for jpeg headers for isImage

### DIFF
--- a/modules/images/src/lib/image-parsers.js
+++ b/modules/images/src/lib/image-parsers.js
@@ -59,8 +59,13 @@ function getBmpSize(dataView) {
 // JPEG
 
 function isJpeg(dataView) {
-  // Check file contains the JPEG "start of image" (SOI) marker.
-  return dataView.byteLength >= 2 && dataView.getUint16(0, BIG_ENDIAN) === 0xffd8;
+  // Check file contains the JPEG "start of image" (SOI) marker
+  // followed by another marker.
+  return (
+    dataView.byteLength >= 3 &&
+    dataView.getUint16(0, BIG_ENDIAN) === 0xffd8 &&
+    dataView.getUint8(2, BIG_ENDIAN) === 0xff
+  );
 }
 
 // Extract width and height from a binary JPEG file


### PR DESCRIPTION
Only the first 2 bytes where being tested. This adds a test for
the 1st byte of the second marker.

Validating the End Of Image would make this more robust, but since
it is expected to test on partial data adding that is not reasonable
at this time.

See the added test case for floating point values that encode as the valid
jpeg header values.