### PR TITLE
Fix image loader in FF

### DIFF
--- a/docs/api-reference/images/image-loader.md
+++ b/docs/api-reference/images/image-loader.md
@@ -7,7 +7,7 @@ An image loader that works under both Node.js (requires `@loaders.gl/polyfills`)
 | File Extension | `.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`, `.bmp`, `.ico`, `.svg`         |
 | File Type      | Binary         |
 | File Format    | Image          |
-| Data Format    | `Image`, `ImageBitmap` or ndarray (Node) |
+| Data Format    | `Image`, `ImageBitmap` (web worker) or ndarray (node.js) |
 | Decoder Type   | Asynchronous   |
 | Worker Thread  | No             |
 | Streaming      | No             |
@@ -27,8 +27,6 @@ const image = await load(url, ImageLoader, options);
 | Option        | Type      | Default     | Description       |
 | ------------- | --------- | ----------- | ----------------- |
 | `crossOrigin` | String    | -           | passed to [Image.crossorigin](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img). |
-| `imageOrientation` | String | `'none'` | passed to [createImageBitmap](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/createImageBitmap). |
-| `premultiplyAlpha` | String | `'default'` | passed to [createImageBitmap](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/createImageBitmap). |
 
 ## Remarks
 

--- a/modules/images/src/image-loader.js
+++ b/modules/images/src/image-loader.js
@@ -1,10 +1,5 @@
-import {
-  canParseImage,
-  parseImage,
-  loadImage,
-  parseToImageBitmap,
-  loadToHTMLImage
-} from './lib/parse-image';
+/* global Image */
+import {canParseImage, parseImage, parseToImageBitmap, loadToHTMLImage} from './lib/parse-image';
 
 const EXTENSIONS = ['png', 'jpg', 'jpeg', 'gif', 'webp', 'bmp', 'ico', 'svg'];
 
@@ -13,7 +8,7 @@ export default {
   name: 'Images',
   extensions: EXTENSIONS,
   parse: canParseImage && parseImage,
-  loadAndParse: !canParseImage && loadImage
+  loadAndParse: typeof Image !== 'undefined' && loadToHTMLImage
 };
 
 // EXPERIMENTAL

--- a/modules/images/src/lib/parse-image.js
+++ b/modules/images/src/lib/parse-image.js
@@ -4,10 +4,6 @@ import {getImageMetadata} from './get-image-metadata';
 
 export const canParseImage = global._parseImageNode || typeof ImageBitmap !== 'undefined';
 
-// Firefox does not support options:
-// https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/createImageBitmap
-let imageBitmapOptionsSupport = true;
-
 // Parse to platform defined type (ndarray on node, ImageBitmap on browser)
 export function parseImage(arrayBuffer, options) {
   if (global._parseImageNode) {
@@ -40,20 +36,7 @@ export function parseToImageBitmap(arrayBuffer, options) {
   }
 
   const blob = new Blob([new Uint8Array(arrayBuffer)]);
-  const opts = {
-    imageOrientation: options.imageOrientation || 'none',
-    premultiplyAlpha: options.premultiplyAlpha || 'default'
-  };
-  if (!imageBitmapOptionsSupport) {
-    return createImageBitmap(blob);
-  }
-  return createImageBitmap(blob, opts).catch(error => {
-    if (error.name === 'TypeError') {
-      imageBitmapOptionsSupport = false;
-      return createImageBitmap(blob);
-    }
-    throw error;
-  });
+  return createImageBitmap(blob);
 }
 
 //

--- a/modules/images/src/lib/parse-image.js
+++ b/modules/images/src/lib/parse-image.js
@@ -4,6 +4,10 @@ import {getImageMetadata} from './get-image-metadata';
 
 export const canParseImage = global._parseImageNode || typeof ImageBitmap !== 'undefined';
 
+// Firefox does not support options:
+// https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/createImageBitmap
+let imageBitmapOptionsSupport = true;
+
 // Parse to platform defined type (ndarray on node, ImageBitmap on browser)
 export function parseImage(arrayBuffer, options) {
   if (global._parseImageNode) {
@@ -36,9 +40,19 @@ export function parseToImageBitmap(arrayBuffer, options) {
   }
 
   const blob = new Blob([new Uint8Array(arrayBuffer)]);
-  return createImageBitmap(blob, {
+  const opts = {
     imageOrientation: options.imageOrientation || 'none',
     premultiplyAlpha: options.premultiplyAlpha || 'default'
+  };
+  if (!imageBitmapOptionsSupport) {
+    return createImageBitmap(blob);
+  }
+  return createImageBitmap(blob, opts).catch(error => {
+    if (error.name === 'TypeError') {
+      imageBitmapOptionsSupport = false;
+      return createImageBitmap(blob);
+    }
+    throw error;
   });
 }
 


### PR DESCRIPTION
For #317 

### Change List

- `ImageLoader` loads to HTML object if possible (best compatibility)
- detect `createImageBitmap` support for options