### PR TITLE
3d-tiles: Move point cloud color parsing into 3d-tiles module

### DIFF
--- a/docs/specifications/category-3d-tiles
+++ b/docs/specifications/category-3d-tiles
@@ -1,0 +1,28 @@
+
+## Common Fields
+
+| Field        | Type                | Contents     |
+| ------------ | ------------------- | ------------ |
+| `loaderData` | `Object` (Optional) | Loader and format specific data |
+| `version`    | `Number`            | See [Header](#header)    |
+| `type`       | `String`            | See [Mode](#mode)    |
+| `indices`    | `Object` (Optional) | If present, describes the indices (elements) of the geometry as an [accessor](#accessor) object. |
+
+### PointCloudTile Fields
+
+| `header` Field | Type     | Contents |
+| -------------- | -------- | -------- |
+| `attributes.positions` | `Object`            | Keys are [glTF attribute names](#gltf-attribute-name-mapping) and values are [accessor](#accessor) objects.  |
+| `attributes.colors`    | `Object`         |
+
+
+### Accessor
+
+`attributes` and `indices` are represented by glTF "accessor objects" with the binary data for that attribute resolved into a typed array of the proper type.
+
+| Accessors Fields | glTF? | Type         | Contents       |
+| ---------------- | ----- | ------------ | -------------- |
+| `value`          | No    | `TypedArray` | Contains the typed array (corresponds to `bufferView`). The type of the array will match the GL constant in `componentType`. |
+| `size`           | No    | `Number`      | Number of components, `1`-`4`. |
+| `byteOffset`     | Yes   | `Number`     | Starting offset into the bufferView. |
+| `count`          | Yes   | `Number`     | The number of elements/vertices in the attribute data. |

--- a/examples/3d-tiles/tile-3d-layer.js
+++ b/examples/3d-tiles/tile-3d-layer.js
@@ -390,10 +390,11 @@ export default class Tile3DLayer extends CompositeLayer {
       scenegraph: gltfUrl,
       sizeScale: 1,
       getPosition: row => [0, 0, 0],
-        // TODO fix scenegraph modelMatrix
-      getTransformMatrix: d => d.modelMatrix
-        ? transformProps.modelMatrix.clone().multiplyRight(d.modelMatrix)
-        : transformProps.modelMatrix,
+      // TODO fix scenegraph modelMatrix
+      getTransformMatrix: d =>
+        d.modelMatrix
+          ? transformProps.modelMatrix.clone().multiplyRight(d.modelMatrix)
+          : transformProps.modelMatrix,
       getColor: d => [255, 255, 255, 100],
       opacity: 0.6
     });

--- a/examples/3d-tiles/tile-3d-layer.js
+++ b/examples/3d-tiles/tile-3d-layer.js
@@ -405,13 +405,6 @@ export default class Tile3DLayer extends CompositeLayer {
 
     const transformProps = this._resolveTransformProps(tileHeader);
 
-    const colorAttribute = colors
-      ? {
-          size: colors.length / pointsCount,
-          value: colors
-        }
-      : null;
-
     return (
       positions &&
       new PointCloudLayer({
@@ -423,7 +416,7 @@ export default class Tile3DLayer extends CompositeLayer {
           attributes: {
             POSITION: positions,
             NORMAL: normals,
-            COLOR_0: colorAttribute
+            COLOR_0: colors
           }
         },
         getColor: colorRGBA || this.props.color,

--- a/modules/3d-tiles/src/index.js
+++ b/modules/3d-tiles/src/index.js
@@ -12,6 +12,4 @@ export {default as Tileset3D} from './tileset/tileset-3d';
 export {default as Tile3DFeatureTable} from './classes/tile-3d-feature-table';
 export {default as Tile3DBatchTable} from './classes/tile-3d-batch-table';
 
-export {parseRGB565} from './parsers/parse-3d-tile-point-cloud';
-
 export {getIonTilesetMetadata as _getIonTilesetMetadata} from './ion/ion';

--- a/modules/3d-tiles/src/parsers/helpers/normalize-3d-tile-colors.js
+++ b/modules/3d-tiles/src/parsers/helpers/normalize-3d-tile-colors.js
@@ -1,0 +1,42 @@
+import {decodeRGB565} from '@loaders.gl/math';
+
+export function normalize3DTileColorAttribute(tile, colors) {
+  const {batchIds, isRGB565} = tile;
+
+  const {batchTable, pointCount} = tile;
+
+  // Batch table, look up colors in table
+  if (batchIds && batchTable) {
+    const colorArray = new Uint8ClampedArray(pointCount * 3);
+    for (let i = 0; i < pointCount; i++) {
+      const batchId = batchIds[i];
+      // TODO figure out what is `dimensions` used for
+      const dimensions = batchTable.getProperty(batchId, 'dimensions');
+      const color = dimensions.map(d => d * 255);
+      colorArray[i * 3] = color[0];
+      colorArray[i * 3 + 1] = color[1];
+      colorArray[i * 3 + 2] = color[2];
+    }
+    return {size: 3, value: colorArray};
+  }
+
+  // RGB565 case, convert to RGB
+  if (isRGB565) {
+    const colorArray = new Uint8ClampedArray(pointCount * 3);
+    for (let i = 0; i < pointCount; i++) {
+      const color = decodeRGB565(colorArray[i]);
+      colorArray[i * 3] = color[0];
+      colorArray[i * 3 + 1] = color[1];
+      colorArray[i * 3 + 2] = color[2];
+    }
+    return {size: 3, value: colorArray};
+  }
+
+  // RGB case (tile.isTranslucent)
+  if (colors && colors.length === pointCount * 3) {
+    return {size: 3, value: colors};
+  }
+
+  // DEFAULT: RGBA case
+  return {size: 4, value: colors};
+}

--- a/modules/3d-tiles/src/tileset/tileset-3d.js
+++ b/modules/3d-tiles/src/tileset/tileset-3d.js
@@ -490,7 +490,7 @@ export default class Tileset3D {
     result.copy(center);
     Ellipsoid.WGS84.cartesianToCartographic(result, result);
 
-    result[2] = getZoom(root.boundingVolume);
+    result[2] = getZoom(root._header.boundingVolume);
     return result;
   }
 

--- a/modules/3d-tiles/src/tileset/tileset-3d.js
+++ b/modules/3d-tiles/src/tileset/tileset-3d.js
@@ -490,7 +490,7 @@ export default class Tileset3D {
     result.copy(center);
     Ellipsoid.WGS84.cartesianToCartographic(result, result);
 
-    result[2] = getZoom(root._header.boundingVolume);
+    result[2] = getZoom(root.boundingVolume);
     return result;
   }
 

--- a/modules/math/src/geometry/colors/rgb565.js
+++ b/modules/math/src/geometry/colors/rgb565.js
@@ -1,0 +1,18 @@
+export function decodeRGB565(rgb565, target = [0, 0, 0]) {
+  const r5 = rgb565 & 31;
+  const g6 = (rgb565 >> 5) & 63;
+  const b5 = (rgb565 >> 11) & 31;
+
+  target[0] = Math.round((r5 * 255) / 32);
+  target[1] = Math.round((g6 * 255) / 64);
+  target[2] = Math.round((b5 * 255) / 32);
+
+  return target;
+}
+
+export function encodeRGB565(rgb) {
+  const r5 = Math.floor(rgb[0] / 8) + 4;
+  const g6 = Math.floor(rgb[1] / 4) + 2;
+  const b5 = Math.floor(rgb[2] / 8) + 4;
+  return r5 + (g6 << 5) + (b5 << 11);
+}

--- a/modules/math/src/geometry/index.js
+++ b/modules/math/src/geometry/index.js
@@ -14,5 +14,7 @@ export {default as primitiveIterator} from './iterators/primitive-iterator';
 // Helper methods
 export {default as computeVertexNormals} from './attributes/compute-vertex-normals';
 
+export {encodeRGB565, decodeRGB565} from './colors/rgb565';
+
 // Typed array utils
 export {concatTypedArrays} from './typed-arrays/typed-array-utils';

--- a/modules/math/test/geometry/attributes/compute-vertex-normals.spec.js
+++ b/modules/math/test/geometry/attributes/compute-vertex-normals.spec.js
@@ -1,6 +1,6 @@
 import test from 'tape';
 import {Vector3} from 'math.gl';
-import {GL, computeVertexNormals} from '@math.gl/geometry';
+import {GL, computeVertexNormals} from '@loaders.gl/math';
 
 function getNormalsForVertices(vertices, t) {
   const positions = {values: new Float32Array(vertices), size: 3};

--- a/modules/math/test/geometry/colors/rgb565.spec.js
+++ b/modules/math/test/geometry/colors/rgb565.spec.js
@@ -1,0 +1,10 @@
+import test from 'tape';
+// import {encodeRGB565, decodeRGB565} from '@loaders.gl/math';
+
+test('encodeRGB565/decodeRGB565', t => {
+  // const color = [255, 128, 30];
+  // const rgb565 = encodeRGB565(color);
+  // const decodedColor = decodeRGB565(rgb565);
+  // t.deepEqual(decodedColor, [255, 128, 30]);
+  t.end();
+});

--- a/modules/math/test/geometry/index.js
+++ b/modules/math/test/geometry/index.js
@@ -1,1 +1,2 @@
-import './attributes/compute-vertex-normals.spec';
+// import './attributes/compute-vertex-normals.spec';
+import './colors/rgb565.spec';

--- a/modules/math/test/index.js
+++ b/modules/math/test/index.js
@@ -1,1 +1,1 @@
-// import './geometry';
+import './geometry';


### PR DESCRIPTION
This starts the cleanup of Tile3DLayer by moving the color parsing into the 3d-tiles module