### PR TITLE
3d-tiles: traverser no longer knows about tileset

### DIFF
--- a/modules/3d-tiles/src/tileset/tileset-3d-traverser.js
+++ b/modules/3d-tiles/src/tileset/tileset-3d-traverser.js
@@ -23,7 +23,7 @@ export default class Tileset3DTraverser {
       _emptyTiles: [],
       _hasMixedContent: false
     };
-      }
+  }
 
   traverse(root, frameState, options) {
     this.root = root; // for root screen space error

--- a/modules/3d-tiles/src/tileset/tileset-3d.js
+++ b/modules/3d-tiles/src/tileset/tileset-3d.js
@@ -312,6 +312,7 @@ export default class Tileset3D {
     this._updatedVisibilityFrame++; // TODO: only update when camera or culling volume from last update moves (could be render camera change or prefetch camera)
     this._cache.reset();
 
+    // eslint-disable-next-line consistent-this
     const options = this; // TODO: hack, create separate options field
     this._traverser.traverse(this.root, frameState, options);
     Object.assign(this, this._traverser.result); // Hack during refactor

--- a/modules/3d-tiles/src/tileset/tileset-3d.js
+++ b/modules/3d-tiles/src/tileset/tileset-3d.js
@@ -312,7 +312,9 @@ export default class Tileset3D {
     this._updatedVisibilityFrame++; // TODO: only update when camera or culling volume from last update moves (could be render camera change or prefetch camera)
     this._cache.reset();
 
-    this._traverser.traverse(this, frameState);
+    const options = this; // TODO: hack, create separate options field
+    this._traverser.traverse(this.root, frameState, options);
+    Object.assign(this, this._traverser.result); // Hack during refactor
 
     const requestedTiles = this._requestedTiles;
     // Sort requests by priority before making any requests.


### PR DESCRIPTION
@loshjawrence The fact that `Tileset3DTraverser` had full access to `Tileset3D` made these classes highly coupled and it was quite hard for me to follow what was going on.

With this refactor, the traverser no longer gets passed the tileset, but just the root tile and the options.

This works, but I had to disable one line in "cache touching" as we don't have access to the cache, however we can easily restore that to tileset (e.g. with an `onTileTouched` callback or a `touchedTiles` array, or we could pass in the cache).

The cache was not functional anyway as far as I could tell (never unloaded) so this should be OK for now.

Let me know if you have any major concerns before I land.