### PR TITLE
core: Name workers for debugger

### DIFF
--- a/modules/core/src/lib/parse-with-loader.js
+++ b/modules/core/src/lib/parse-with-loader.js
@@ -33,7 +33,7 @@ export async function parseWithLoader(data, loader, options, url) {
   }
 
   if (loader.worker) {
-    return parseWithWorker(loader.worker, data, options);
+    return parseWithWorker(loader.worker, loader.name, data, options);
   }
 
   // TBD - If asynchronous parser not available, return null

--- a/modules/core/src/lib/parse-with-worker.js
+++ b/modules/core/src/lib/parse-with-worker.js
@@ -15,7 +15,7 @@ function getDecoratedWorkerName(workerName) {
 function getWorker(workerSource, workerName) {
   let workerURL = workerCache.get(workerSource);
   if (!workerURL) {
-    const blob = new Blob([workerSource], { type: 'application/javascript' });
+    const blob = new Blob([workerSource], {type: 'application/javascript'});
     workerURL = URL.createObjectURL(blob);
     workerCache.set(workerSource, workerURL);
   }

--- a/modules/core/src/lib/parse-with-worker.js
+++ b/modules/core/src/lib/parse-with-worker.js
@@ -2,19 +2,28 @@ import {toArrayBuffer} from '../javascript-utils/binary-utils';
 
 const workerCache = new Map();
 
+const counters = {};
+
+function getDecoratedWorkerName(workerName) {
+  const lowerCaseName = workerName ? workerName.toLowerCase() : 'unnamed';
+  counters[lowerCaseName] = counters[lowerCaseName] || 0;
+  const counter = counters[lowerCaseName]++;
+  return `loaders.gl-${lowerCaseName}-worker-${counter}`;
+}
+
 /* global Worker, Blob, URL */
-function getWorker(workerSource) {
+function getWorker(workerSource, workerName) {
   let workerURL = workerCache.get(workerSource);
   if (!workerURL) {
-    const blob = new Blob([workerSource], {type: 'application/javascript'});
+    const blob = new Blob([workerSource], { type: 'application/javascript' });
     workerURL = URL.createObjectURL(blob);
     workerCache.set(workerSource, workerURL);
   }
-  return new Worker(workerURL);
+  return new Worker(workerURL, {name: getDecoratedWorkerName(workerName)});
 }
 
-export default function parseWithWorker(workerSource, data, options) {
-  const worker = getWorker(workerSource);
+export default function parseWithWorker(workerSource, workerName, data, options) {
+  const worker = getWorker(workerSource, workerName);
 
   options = removeNontransferableOptions(options);
 


### PR DESCRIPTION
In Chrome 70, workers now have a name attribute, 
```new Worker(url, {name: 'worker name'});```

https://developers.google.com/web/updates/2018/10/nic70


Screenshot with our workers after mapbox workers:

<img width="289" alt="Screen Shot 2019-08-20 at 5 10 42 PM" src="https://user-images.githubusercontent.com/7025232/63392958-bb231180-c36d-11e9-9444-259d76db6dc5.png">
