### PR TITLE
 3d-tiles: Support loading of nested tilesets with local url folders

### DIFF
--- a/examples/3d-tiles/app.js
+++ b/examples/3d-tiles/app.js
@@ -18,9 +18,10 @@ const DATA_URI = 'https://raw.githubusercontent.com/uber-web/loaders.gl/master';
 const INDEX_FILE = `${DATA_URI}/modules/3d-tiles/test/data/index.json`;
 
 // eslint-disable-next-line
-const ION_ACCESS_TOKEN =
+const ION_ACCESS_TOKEN_1 =
   'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIxN2NhMzkwYi0zNWM4LTRjNTYtYWE3Mi1jMDAxYzhlOGVmNTAiLCJpZCI6OTYxOSwic2NvcGVzIjpbImFzbCIsImFzciIsImFzdyIsImdjIl0sImlhdCI6MTU2MjE4MTMxM30.OkgVr6NaKYxabUMIGqPOYFe0V5JifXLVLfpae63x-tA';
-
+const ION_ACCESS_TOKEN_2 =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIzMGY4ODczYy1mNTk4LTRiMDUtYmIxYy0xZWYwOWZmMGY4NjQiLCJpZCI6NDQsInNjb3BlcyI6WyJhc3IiLCJnYyJdLCJhc3NldHMiOlsxLDIsMyw0LDYxOTMsNjI3Myw3MTYyLDczNTMsNzE0Ml0sImlhdCI6MTU0MTYxODM0NX0.lWnGs9ySXO4QK3HagcMsDpZ8L01DpmUDQm38-2QAQuE';
 // Set your mapbox token here
 const MAPBOX_TOKEN = process.env.MapboxAccessToken; // eslint-disable-line
 
@@ -40,14 +41,13 @@ const ADDITIONAL_EXAMPLES = {
         'https://raw.githubusercontent.com/uber-common/deck.gl-data/master/3d-tiles/RoyalExhibitionBuilding/tileset.json',
       color: [115, 101, 152, 200]
     },
+    '6193 (Cesium Ion Batched)': {ionAssetId: 6193, ionAccessToken: ION_ACCESS_TOKEN_2},
+    '7162 (Cesium Ion Batched)': {ionAssetId: 7162, ionAccessToken: ION_ACCESS_TOKEN_2},
     'Mount St Helens (Cesium Ion PointCloud)': {
       ionAssetId: 33301,
-      ionAccessToken: ION_ACCESS_TOKEN
+      ionAccessToken: ION_ACCESS_TOKEN_1
     },
-    'Montreal (Cesium Ion PointCloud)': {
-      ionAssetId: 28945,
-      ionAccessToken: ION_ACCESS_TOKEN
-    }
+    'Montreal (Cesium Ion PointCloud)': {ionAssetId: 28945, ionAccessToken: ION_ACCESS_TOKEN_1}
   }
 };
 
@@ -140,7 +140,7 @@ export default class App extends PureComponent {
     let ionAccessToken = parsedUrl.searchParams.get('ionAccessToken');
     if (ionAssetId || ionAccessToken) {
       // load the tileset specified in the URL
-      ionAccessToken = ionAccessToken || ION_ACCESS_TOKEN;
+      ionAccessToken = ionAccessToken || ION_ACCESS_TOKEN_1;
       await this._loadTilesetFromIonAsset(ionAccessToken, ionAssetId);
       return;
     }

--- a/modules/3d-tiles/src/tileset-3d-loader.js
+++ b/modules/3d-tiles/src/tileset-3d-loader.js
@@ -1,6 +1,6 @@
 export default {
   name: '3D Tileset',
   extensions: ['json'],
-  testText: text => text.indexOf('tilesetVersion' >= 0),
+  testText: text => text.indexOf('asset' >= 0),
   parseTextSync: JSON.parse
 };

--- a/modules/3d-tiles/src/tileset/tile-3d-header.js
+++ b/modules/3d-tiles/src/tileset/tile-3d-header.js
@@ -3,13 +3,12 @@
 // import {TILE3D_REFINEMENT, TILE3D_OPTIMIZATION_HINT} from '../constants';
 import {Vector3, Matrix4} from 'math.gl';
 import {CullingVolume} from '@math.gl/culling';
+import {parse, fetchFile, path} from '@loaders.gl/core';
 import Tile3DLoader from '../tile-3d-loader';
 import Tileset3DLoader from '../tileset-3d-loader';
 import {TILE3D_REFINEMENT, TILE3D_CONTENT_STATE, TILE3D_OPTIMIZATION_HINT} from '../constants';
 import assert from '../utils/assert';
 import {createBoundingVolume} from './helpers/bounding-volume';
-// TODO - inject this dependency?
-import {parse, fetchFile, path} from '@loaders.gl/core';
 
 const defined = x => x !== undefined && x !== null;
 
@@ -303,7 +302,6 @@ export default class Tile3DHeader {
 
       // The content can be a binary tile ot a JSON tileset
       this._content = await parse(response, [Tile3DLoader, Tileset3DLoader], {DracoLoader});
-
       // if (Tile3D.isTile(content)) {
       //   new Tileset3D(content, contentUri);
 

--- a/modules/3d-tiles/src/tileset/tile-3d-header.js
+++ b/modules/3d-tiles/src/tileset/tile-3d-header.js
@@ -303,6 +303,7 @@ export default class Tile3DHeader {
 
       // The content can be a binary tile ot a JSON tileset
       this._content = await parse(response, [Tile3DLoader, Tileset3DLoader], {DracoLoader});
+
       // if (Tile3D.isTile(content)) {
       //   new Tileset3D(content, contentUri);
 
@@ -612,7 +613,7 @@ export default class Tile3DHeader {
 
   _contentLoaded() {
     // Vector and Geometry tile rendering do not support the skip LOD optimization.
-    switch (this._content.type) {
+    switch (this._content && this._content.type) {
       case 'vctr':
       case 'geom':
         tileset.traverser.disableSkipLevelOfDetail = true;

--- a/modules/core/src/lib/loader-utils/auto-detect-loader.js
+++ b/modules/core/src/lib/loader-utils/auto-detect-loader.js
@@ -1,6 +1,6 @@
 import {normalizeLoader} from './normalize-loader';
 
-const EXT_PATTERN = /[^.]+$/;
+const EXT_PATTERN = /[^.]+.([^?]+)$/;
 
 // Find a loader that works for extension/text
 // Search the loaders array argument for a loader that matches extension or text
@@ -16,7 +16,7 @@ export function autoDetectLoader(data, loaders, {url = ''} = {}) {
 function findLoaderByUrl(loaders, url) {
   // Get extension
   const match = url.match(EXT_PATTERN);
-  const extension = match && match[0];
+  const extension = match && match.length >= 1 && match[1];
   const loader = extension && findLoaderByExtension(loaders, extension);
   return loader;
 }

--- a/modules/core/src/lib/loader-utils/auto-detect-loader.js
+++ b/modules/core/src/lib/loader-utils/auto-detect-loader.js
@@ -1,10 +1,11 @@
 import {normalizeLoader} from './normalize-loader';
 
-const EXT_PATTERN = /[^.]+.([^?]+)$/;
+const EXT_PATTERN = /[^.]+$/;
 
 // Find a loader that works for extension/text
 // Search the loaders array argument for a loader that matches extension or text
 export function autoDetectLoader(data, loaders, {url = ''} = {}) {
+  url = url.replace(/\?.*/, '');
   let loader = null;
   loader = loader || findLoaderByUrl(loaders, url);
   loader = loader || findLoaderByExamingInitialData(loaders, data);
@@ -16,7 +17,7 @@ export function autoDetectLoader(data, loaders, {url = ''} = {}) {
 function findLoaderByUrl(loaders, url) {
   // Get extension
   const match = url.match(EXT_PATTERN);
-  const extension = match && match.length >= 1 && match[1];
+  const extension = match && match[0];
   const loader = extension && findLoaderByExtension(loaders, extension);
   return loader;
 }

--- a/modules/core/src/lib/loader-utils/get-data.js
+++ b/modules/core/src/lib/loader-utils/get-data.js
@@ -13,8 +13,17 @@ import {checkFetchResponseStatus, checkFetchResponseStatusSync} from './check-er
 
 const ERR_DATA = 'Cannot convert supplied data type';
 
-export function getUrlFromData(data) {
-  return isFetchResponse(data) ? data.url : null;
+// Extract a URL from `parse` arguments if possible
+// If a fetch Response object or File/Blob were passed in get URL from those objects
+export function getUrlFromData(data, url) {
+  if (isFetchResponse(data)) {
+    url = url || data.url;
+  } else if (isFileReadable(url)) {
+    // File or Blob
+    url = url.name;
+  }
+  // Strip any query string
+  return typeof url === 'string' ? url.replace(/\?.*/, '') : url;
 }
 
 export function getArrayBufferOrStringFromDataSync(data, loader) {

--- a/modules/core/src/lib/loader-utils/get-data.js
+++ b/modules/core/src/lib/loader-utils/get-data.js
@@ -104,3 +104,22 @@ export function getIteratorFromData(data) {
 
   throw new Error(ERR_DATA);
 }
+
+async function checkFetchResponseStatus(response) {
+  if (!response.ok) {
+    let errorMessage = `fetch failed ${response.status} `;
+    try {
+      const text = await response.text();
+      errorMessage += text;
+    } catch (error) {
+      // ignore error
+    }
+    throw new Error(errorMessage);
+  }
+}
+
+async function checkFetchResponseStatusSync(response) {
+  if (!response.ok) {
+    throw new Error(`fetch failed ${response.status}`);
+  }
+}

--- a/modules/core/src/lib/loader-utils/get-data.js
+++ b/modules/core/src/lib/loader-utils/get-data.js
@@ -104,22 +104,3 @@ export function getIteratorFromData(data) {
 
   throw new Error(ERR_DATA);
 }
-
-async function checkFetchResponseStatus(response) {
-  if (!response.ok) {
-    let errorMessage = `fetch failed ${response.status} `;
-    try {
-      const text = await response.text();
-      errorMessage += text;
-    } catch (error) {
-      // ignore error
-    }
-    throw new Error(errorMessage);
-  }
-}
-
-async function checkFetchResponseStatusSync(response) {
-  if (!response.ok) {
-    throw new Error(`fetch failed ${response.status}`);
-  }
-}

--- a/modules/core/src/lib/parse-with-loader.js
+++ b/modules/core/src/lib/parse-with-loader.js
@@ -4,16 +4,13 @@ import {
   getArrayBufferOrStringFromDataSync,
   getArrayBufferOrStringFromData,
   getAsyncIteratorFromData,
-  getIteratorFromData,
-  // getLengthFromData,
-  getUrlFromData
+  getIteratorFromData
 } from './loader-utils/get-data';
 
 // TODO: support progress and abort
 // TODO: support moving loading to worker
 // TODO - should accept loader.parseAsyncIterator and concatenate.
 export async function parseWithLoader(data, loader, options, url) {
-  url = url || getUrlFromData(data);
   data = await getArrayBufferOrStringFromData(data, loader);
 
   // First check for synchronous text parser, wrap results in promises

--- a/modules/core/src/lib/parse.js
+++ b/modules/core/src/lib/parse.js
@@ -1,10 +1,9 @@
-import {isFetchResponse, isFileReadable} from '../javascript-utils/is-type';
 import {autoDetectLoader} from './loader-utils/auto-detect-loader';
 import {normalizeLoader, isLoaderObject} from './loader-utils/normalize-loader';
 import {mergeLoaderAndUserOptions} from './loader-utils/normalize-options';
+import {getUrlFromData} from './loader-utils/get-data';
 import {getRegisteredLoaders} from './register-loaders';
 import {parseWithLoader, parseWithLoaderInBatches, parseWithLoaderSync} from './parse-with-loader';
-import {getUrlFromData} from './loader-utils/get-data';
 
 export async function parse(data, loaders, options, url) {
   // Signature: parse(data, options, url)

--- a/modules/core/src/lib/parse.js
+++ b/modules/core/src/lib/parse.js
@@ -4,18 +4,7 @@ import {normalizeLoader, isLoaderObject} from './loader-utils/normalize-loader';
 import {mergeLoaderAndUserOptions} from './loader-utils/normalize-options';
 import {getRegisteredLoaders} from './register-loaders';
 import {parseWithLoader, parseWithLoaderInBatches, parseWithLoaderSync} from './parse-with-loader';
-
-// Extract a URL from `parse` arguments if possible
-// If a fetch Response object or File/Blob were passed in get URL from those objects
-function getUrl(data, url) {
-  if (isFetchResponse(data)) {
-    return url || data.url;
-  }
-  if (isFileReadable(url)) {
-    return url.name;
-  }
-  return url;
-}
+import {getUrlFromData} from './loader-utils/get-data';
 
 export async function parse(data, loaders, options, url) {
   // Signature: parse(data, options, url)
@@ -27,7 +16,7 @@ export async function parse(data, loaders, options, url) {
   }
 
   // Extract a url for auto detection
-  const autoUrl = getUrl(data, url);
+  const autoUrl = getUrlFromData(data, url);
 
   loaders = loaders || getRegisteredLoaders();
   const loader = Array.isArray(loaders) ? autoDetectLoader(data, loaders, {url: autoUrl}) : loaders;


### PR DESCRIPTION
Slightly big PR, could split it if hard to review:

- Add `Batched3DModel` samples to 3d-tiles example
- Store local `basePath` in `Tile3DHeaders` loaded from "nested" tilesets.
- Move to pure `parse` calls when loading tiles dynamically
- Some cleanup in `Tileset3D` class 
