### PR TITLE
3d-tiles: Add experimental RequestScheduler and throttleRequests option.

### DIFF
--- a/examples/3d-tiles/tile-3d-layer/tile-3d-layer.js
+++ b/examples/3d-tiles/tile-3d-layer/tile-3d-layer.js
@@ -65,6 +65,7 @@ export default class Tile3DLayer extends CompositeLayer {
       const tilesetJson = await response.json();
 
       tileset3d = new Tileset3D(tilesetJson, tilesetUrl, {
+        throttleRequests: true,
         onTileLoad: tileHeader => {
           this.props.onTileLoad(tileHeader);
           this._updateTileset(tileset3d);

--- a/modules/3d-tiles/src/index.js
+++ b/modules/3d-tiles/src/index.js
@@ -12,4 +12,6 @@ export {default as Tileset3D} from './tileset/tileset-3d';
 export {default as Tile3DFeatureTable} from './classes/tile-3d-feature-table';
 export {default as Tile3DBatchTable} from './classes/tile-3d-batch-table';
 
+// EXPERIMENTAL
+
 export {getIonTilesetMetadata as _getIonTilesetMetadata} from './ion/ion';

--- a/modules/3d-tiles/src/request-utils/request-scheduler.js
+++ b/modules/3d-tiles/src/request-utils/request-scheduler.js
@@ -1,0 +1,139 @@
+// TODO - this should move to core when test cases are more complete
+
+/* global setTimeout */
+import {Stats} from 'probe.gl';
+
+const STAT_QUEUED_REQUESTS = 'Queued Requests';
+const STAT_ACTIVE_REQUESTS = 'Active Requests';
+const STAT_CANCELLED_REQUESTS = 'Cancelled Requests';
+const STAT_QUEUED_REQUESTS_EVER = 'Queued Requests Ever';
+const STAT_ACTIVE_REQUESTS_EVER = 'Active Requests Ever';
+
+const DEFAULT_PROPS = {
+  id: 'request-scheduler',
+  // Specifies if the request scheduler should throttle incoming requests, mainly for comparative testing
+  throttleRequests: true,
+  // The maximum number of simultaneous active requests. Un-throttled requests do not observe this limit.
+  maxRequests: 6
+};
+
+// The request scheduler does not actually issue requests, it just lets apps know
+// when the request can be issued without overwhelming the server.
+// The main use case is to let the app  reprioritize or cancel requests if
+//  circumstances change before the request can be scheduled.
+//
+// TODO - Track requests globally, across multiple servers
+export default class RequestScheduler {
+  constructor(props = {}) {
+    this.props = {...props, ...DEFAULT_PROPS};
+
+    // Tracks the number of active requests and prioritizes/cancels queued requests.
+    this.requestQueue = [];
+    this.activeRequestCount = 0;
+
+    // Returns the statistics used by the request scheduler.
+    this.stats = new Stats({id: props.id});
+    this.stats.get(STAT_QUEUED_REQUESTS);
+    this.stats.get(STAT_ACTIVE_REQUESTS);
+    this.stats.get(STAT_CANCELLED_REQUESTS);
+    this.stats.get(STAT_QUEUED_REQUESTS_EVER);
+    this.stats.get(STAT_ACTIVE_REQUESTS_EVER);
+  }
+
+  // Called by an application that wants to issue a request, without having it deeply queued
+  // Parameter `callback` will be called when request "slots" open up,
+  //    allowing the caller to update priority or cancel the request
+  //    Highest priority executes first, priority < 0 cancels the request
+  // Returns: a promise that resolves when the request can be issued without queueing,
+  //    or rejects if the request has been cancelled (by the callback)
+  scheduleRequest(handle, callback = () => 0) {
+    // Allows throttling to be disabled
+    if (!this.props.throttleRequests) {
+      return Promise.resolve(handle);
+    }
+
+    const promise = new Promise((resolve, reject) => {
+      this.requestQueue.push({handle, callback, resolve, reject});
+    });
+
+    this._issueNewRequests();
+    return promise;
+  }
+
+  // Called by an application to mark that it is actively making a request
+  startRequest(handle) {
+    this.activeRequestCount++;
+  }
+
+  // Called by an application to mark that it is finished making a request
+  endRequest(handle) {
+    this.activeRequestCount--;
+    this._issueNewRequests();
+  }
+
+  // Tracks a request promise, starting and then ending the request (triggering new slots).
+  trackRequestPromise(handle, promise) {
+    this.startRequest(handle);
+    promise.then(() => this.endRequest(handle)).catch(() => this.endRequest(handle));
+  }
+
+  // PRIVATE
+
+  // We check requests asynchronously, to prevent multiple updates
+  _issueNewRequests() {
+    this._updateNeeded = true;
+    setTimeout(() => this._issueNewRequestsAsync(), 0);
+  }
+
+  // Refresh all requests and
+  _issueNewRequestsAsync() {
+    this._updateNeeded = false;
+
+    const freeSlots = Math.max(this.props.maxRequests - this.activeRequestCount, 0);
+
+    if (freeSlots === 0) {
+      return;
+    }
+
+    this._updateAllRequests();
+
+    // Resolve pending promises for the top-priority requests
+    for (let i = 0; i < freeSlots; ++i) {
+      if (this.requestQueue.length > 0) {
+        const request = this.requestQueue.shift();
+        request.resolve(true);
+      }
+    }
+
+    // Uncomment to debug
+    // console.log(`${freeSlots} free slots, ${this.requestQueue.length} queued requests`);
+  }
+
+  // Ensure all requests have updated priorities, and that no longer valid requests are cancelled
+  _updateAllRequests() {
+    const requestQueue = this.requestQueue;
+    for (let i = 0; i < requestQueue.length; ++i) {
+      const request = requestQueue[i];
+      if (!this._updateRequest(request)) {
+        // Remove the element and make sure to adjust the counter to account for shortened array
+        requestQueue.splice(i, 1);
+        i--;
+      }
+    }
+
+    // Sort the remaining requests based on priority
+    requestQueue.sort((a, b) => a.priority - b.priority);
+  }
+
+  // Update a single request by calling the callback
+  _updateRequest(request) {
+    request.priority = request.callback(request.handle); // eslint-disable-line callback-return
+
+    // by returning a negative priority, the callback cancels the request
+    if (request.priority < 0) {
+      request.resolve(false);
+      return false;
+    }
+    return true;
+  }
+}

--- a/modules/3d-tiles/test/index.js
+++ b/modules/3d-tiles/test/index.js
@@ -1,3 +1,5 @@
+import './request-utils/request-scheduler.spec';
+
 import './classes/tile-3d-feature-table.spec';
 import './classes/tile-3d-batch-table.spec';
 

--- a/modules/3d-tiles/test/request-utils/request-scheduler.spec.js
+++ b/modules/3d-tiles/test/request-utils/request-scheduler.spec.js
@@ -1,0 +1,21 @@
+import RequestScheduler from '@loaders.gl/3d-tiles/request-utils/request-scheduler';
+import test from 'tape-promise/tape';
+
+test('RequestScheduler#constructor', t => {
+  const requestScheduler = new RequestScheduler();
+  t.ok(requestScheduler);
+  t.end();
+});
+
+test('RequestScheduler#scheduleRequest', async t => {
+  const requestScheduler = new RequestScheduler({maxRequests: 1});
+  t.ok(requestScheduler);
+
+  let result = await requestScheduler.scheduleRequest(1);
+  t.ok(result);
+
+  result = await requestScheduler.scheduleRequest(2, () => -1);
+  t.notOk(result);
+
+  t.end();
+});

--- a/modules/3d-tiles/test/tileset/tileset-3d.spec.js
+++ b/modules/3d-tiles/test/tileset/tileset-3d.spec.js
@@ -378,6 +378,7 @@ test('Tileset3D#handles failed tile processing', t => {
 test('Tileset3D#loads tiles in tileset', async t => {
   const tilesetJson = await parse(fetchFile(TILESET_URL), Tileset3DLoader);
   const tileset = new Tileset3D(tilesetJson, TILESET_URL);
+  tileset.root._visible = true;
   await tileset.root.loadContent();
   t.ok(tileset.root.content);
   t.end();


### PR DESCRIPTION
@loshjawrence - FYI, a minimal naive `RequestScheduler`, as you suggested this seems to dramatically affect performance. 

Now we need testing (and more test cases) to make sure results are correct.

I added a `throttleRequests` option to `Tileset3D` to make it easy to turn on-off. 

@xintongxia - `Tile3dLayer` should probably have a tilesetProps that we pass to `Tileset3D` when we create it...