### PR TITLE
websites: Update to ocular@1.0.0

### DIFF
--- a/arrowjs/website/package.json
+++ b/arrowjs/website/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "gatsby": "^2.13.0",
-    "ocular-gatsby": "1.0.0-alpha.53",
+    "ocular-gatsby": "^1.0.0",
     "sharp": "^0.23.0"
   }
 }

--- a/website/package.json
+++ b/website/package.json
@@ -40,7 +40,7 @@
     "gatsby": "^2.13.51",
     "gatsby-plugin-no-sourcemaps": "^2.0.2",
     "gh-pages": "^2.1.0",
-    "ocular-gatsby": "1.0.0-alpha.53",
+    "ocular-gatsby": "^1.0.0",
     "sharp": "^0.23.0"
   }
 }


### PR DESCRIPTION
Also fixes "full window" examples: https://loaders.gl/examples/3d-tiles