### PR TITLE
3d-tiles: Show attributions for tilesets loaded from ion.

### DIFF
--- a/examples/3d-tiles/app.js
+++ b/examples/3d-tiles/app.js
@@ -53,15 +53,19 @@ export default class App extends PureComponent {
     super(props);
 
     this.state = {
+      // CURRENT VIEW POINT / CAMERA POSITIO
       viewState: INITIAL_VIEW_STATE,
-      featureTable: null,
-      batchTable: null,
+
+      // MAP STATE
+      selectedMapStyle: INITIAL_MAP_STYLE,
+
+      // EXAMPLE STATE
       droppedFile: null,
       examplesByCategory: null,
       selectedExample: {},
       category: INITIAL_EXAMPLE_CATEGORY,
       name: INITIAL_EXAMPLE_NAME,
-      selectedMapStyle: INITIAL_MAP_STYLE
+      attributions: []
     };
 
     this._deckRef = null;
@@ -158,6 +162,7 @@ export default class App extends PureComponent {
 
   // Called by Tile3DLayer when a new tileset is loaded
   _onTilesetLoad(tileset) {
+    this.setState({attributions: tileset.credits.attributions});
     this._tilesetStatsWidget.setStats(tileset.stats);
     this._centerViewOnTileset(tileset);
   }
@@ -196,6 +201,7 @@ export default class App extends PureComponent {
 
   _renderControlPanel() {
     const {examplesByCategory, category, name, viewState, selectedMapStyle} = this.state;
+    const {attributions} = this.state;
     if (!examplesByCategory) {
       return null;
     }
@@ -207,10 +213,11 @@ export default class App extends PureComponent {
         data={examplesByCategory}
         category={category}
         name={name}
+        attributions={attributions}
         onMapStyleChange={this._onSelectMapStyle.bind(this)}
         onExampleChange={this._onSelectExample.bind(this)}
       >
-        <div>
+        <div style={{textAlign: 'center'}}>
           long/lat: {viewState.longitude.toFixed(5)},{viewState.latitude.toFixed(5)}, zoom:{' '}
           {viewState.zoom.toFixed(2)}
         </div>

--- a/examples/3d-tiles/components/control-panel.js
+++ b/examples/3d-tiles/components/control-panel.js
@@ -113,14 +113,31 @@ export default class ControlPanel extends PureComponent {
     return droppedFile ? <div>Dropped file: {JSON.stringify(droppedFile.name)}</div> : null;
   }
 
+  _renderAttributions() {
+    const {attributions} = this.props;
+    if (!attributions || attributions.length === 0) {
+      return null;
+    }
+    return (
+      <div style={{marginTop: '0.5cm'}}>
+        <div style={{textAlign: 'center', borderStyle: 'groove'}}>
+          {Boolean(attributions.length) && <b>Tileset Credentials</b>}
+          {attributions.map(attribution => (
+            <div key={attribution.html} dangerouslySetInnerHTML={{__html: attribution.html}} />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
   render() {
     return (
       <Container>
         {this._renderByCategories()}
         {this._renderDropped()}
-        <div style={{marginBottom: '0.5cm'}} />
         {this._renderMapStyles()}
         {this.props.children}
+        {this._renderAttributions()}
       </Container>
     );
   }


### PR DESCRIPTION
I am not happy with the `dangerouslySetInnerHTML` part, however since ION return credentials as HTML snippets this is the quickest way to implement it. 

There are modules to sanitize HTML but they are quite big, would prefer not to pull them in.

<img width="507" alt="Screen Shot 2019-09-04 at 10 58 05 AM" src="https://user-images.githubusercontent.com/7025232/64279251-749fec00-cf03-11e9-9040-4d95201a0fe4.png">

@Pessimistress 	As you can see this, doesn't look very good, some styling help would make a world of difference...