### PR TITLE
gltf: Improvements to v2.0 gltf parser

### DIFF
--- a/docs/api-reference/gltf/glb-loader.md
+++ b/docs/api-reference/gltf/glb-loader.md
@@ -36,12 +36,12 @@ Returns
 ```json
 {
   header: {
-    type: String,
-    magic: number,
-    version: number,
     byteLength: number,
     byteOffset: number
   },
+
+  type: string,
+  version: number,
 
   // JSON Chunk
   json: any,
@@ -58,14 +58,13 @@ Returns
 
 | Field         | Type          | Default   | Description        |
 | ---           | ---           | ---       | ---                |
-| `header.type` | `String`      | `glTF`      | The first four bytes of the file |
-| `header.magic`   | `Number`      | glTF      | ASCII of the first four bytes of the file |
-| `header.version` | `Number`      | `2`       | The version number |
-| `header.byteLength` | `Number`      | -       | length of GLB (e.g. embedded in larger binary block) |
-| `header.byteOffset` | `Number`      | 0       | offset of GLB  (e.g. embedded in larger binary block) |
+| `type`    | `String`      | `glTF`      | String containing the first four bytes of the file |
+| `version` | `Number`      | `2`       | The version number, only version 2 is supported |
 | `json`    | `Object`      | `{}`      | Parsed JSON from the JSON chunk     |
 | `binChunks`  | `ArrayBuffer` | `null`  | The binary chunk   |
-| `binChunks[0].arrayBuffer`  | `ArrayBuffer` | `null`  | The binary chunk   |
-| `binChunks[0].byteOffset`  | `Number` | `null`  | offset of BIN  (e.g. embedded in larger binary block)   |
-| `binChunks[0].byteLength`  | `ArrayBuffer` | `null`  |length of BIN (e.g. embedded in larger binary block)   |
+| `binChunks[\*].arrayBuffer`  | `ArrayBuffer` | `null`  | The binary chunk   |
+| `binChunks[\*].byteOffset`  | `Number` | `null`  | offset of BIN  (e.g. embedded in larger binary block)   |
+| `binChunks[\*].byteLength`  | `ArrayBuffer` | `null`  |length of BIN (e.g. embedded in larger binary block)   |
+| `header.byteLength` | `Number`      | -       | length of GLB (e.g. embedded in larger binary block) |
+| `header.byteOffset` | `Number`      | 0       | offset of GLB  (e.g. embedded in larger binary block) |
 

--- a/docs/api-reference/gltf/glb-writer.md
+++ b/docs/api-reference/gltf/glb-writer.md
@@ -32,6 +32,8 @@ const arrayBuffer = encodeSync(gltf, GLBWriter, options);
 
 ## Data Format
 
+See `GLBLoader`.
+
 | Field     | Type          | Default   | Description        |
 | ---       | ---           | ---       | ---                |
 | `magic`   | `Number`      | glTF      | The first four bytes of the file |

--- a/docs/api-reference/gltf/gltf-loader.md
+++ b/docs/api-reference/gltf/gltf-loader.md
@@ -95,8 +95,8 @@ Returns
 | `baseUri` | `String`     | ``        | length of GLB (e.g. embedded in larger binary block) |
 | `json`    | `Object`     | `{}`      | Parsed JSON from the JSON chunk     |
 | `buffers` | `Object[]`   | `[]`      | The version number |
-| `buffers[*].arrayBuffer` | `ArrayBuffer` | `null`  | The binary chunk   |
-| `buffers[*].byteOffset`  | `Number`  | `null`  | offset of buffer (embedded in larger binary block)   |
-| `buffers[*].byteLength`  | `ArrayBuffer` | `null`  | length of buffer (embedded in larger binary block)   |
+| `buffers[\*].arrayBuffer` | `ArrayBuffer` | `null`  | The binary chunk   |
+| `buffers[\*].byteOffset`  | `Number`  | `null`  | offset of buffer (embedded in larger binary block)   |
+| `buffers[\*].byteLength`  | `ArrayBuffer` | `null`  | length of buffer (embedded in larger binary block)   |
 | `_glb`?     | `Object`    | N/A       | The output of the GLBLoader if the parsed file was GLB formatted |
 

--- a/modules/core/src/lib/select-loader.js
+++ b/modules/core/src/lib/select-loader.js
@@ -82,7 +82,12 @@ function findLoaderByExamingInitialData(loaders, data) {
         return loader;
       }
     } else if (data instanceof ArrayBuffer) {
-      if (testBinary(data, loader)) {
+      const byteOffset = 0;
+      if (testBinary(data, byteOffset, loader)) {
+        return loader;
+      }
+    } else if (ArrayBuffer.isView(data)) {
+      if (testBinary(data.buffer, data.byteOffset, loader)) {
         return loader;
       }
     }
@@ -95,7 +100,7 @@ function testText(data, loader) {
   return loader.testText && loader.testText(data);
 }
 
-function testBinary(data, loader) {
+function testBinary(data, byteOffset, loader) {
   const type = Array.isArray(loader.test) ? 'array' : typeof loader.test;
   switch (type) {
     case 'function':
@@ -105,9 +110,7 @@ function testBinary(data, loader) {
     case 'array':
       // Magic bytes check: If `loader.test` is a string or array of strings,
       // check if binary data starts with one of those strings
-      const byteOffset = 0;
       const tests = Array.isArray(loader.test) ? loader.test : [loader.test];
-
       return tests.some(test => {
         const magic = getMagicString(data, byteOffset, test.length);
         return test === magic;

--- a/modules/core/src/lib/select-loader.js
+++ b/modules/core/src/lib/select-loader.js
@@ -82,12 +82,7 @@ function findLoaderByExamingInitialData(loaders, data) {
         return loader;
       }
     } else if (data instanceof ArrayBuffer) {
-      const byteOffset = 0;
-      if (testBinary(data, byteOffset, loader)) {
-        return loader;
-      }
-    } else if (ArrayBuffer.isView(data)) {
-      if (testBinary(data.buffer, data.byteOffset, loader)) {
+      if (testBinary(data, loader)) {
         return loader;
       }
     }
@@ -100,7 +95,7 @@ function testText(data, loader) {
   return loader.testText && loader.testText(data);
 }
 
-function testBinary(data, byteOffset, loader) {
+function testBinary(data, loader) {
   const type = Array.isArray(loader.test) ? 'array' : typeof loader.test;
   switch (type) {
     case 'function':
@@ -110,7 +105,9 @@ function testBinary(data, byteOffset, loader) {
     case 'array':
       // Magic bytes check: If `loader.test` is a string or array of strings,
       // check if binary data starts with one of those strings
+      const byteOffset = 0;
       const tests = Array.isArray(loader.test) ? loader.test : [loader.test];
+
       return tests.some(test => {
         const magic = getMagicString(data, byteOffset, test.length);
         return test === magic;

--- a/modules/gltf/src/glb-loader.js
+++ b/modules/gltf/src/glb-loader.js
@@ -7,7 +7,10 @@ export default {
   extension: ['glb'],
   text: true,
   binary: true,
-  parseSync
+  parseSync,
+  defaultOptions: {
+    strict: false // Enables deprecated XVIZ support (illegal CHUNK formats)
+  }
 };
 
 function parseSync(arrayBuffer, options) {

--- a/modules/gltf/src/gltf-loader.js
+++ b/modules/gltf/src/gltf-loader.js
@@ -19,8 +19,7 @@ export async function parse(arrayBuffer, options = {}) {
   // Return pure javascript object
   const {byteOffset = 0} = options;
   const gltf = {};
-  await parseGLTF(gltf, arrayBuffer, byteOffset, options);
-  return gltf;
+  return await parseGLTF(gltf, arrayBuffer, byteOffset, options);
 }
 
 export function parseSync(arrayBuffer, options = {}) {
@@ -35,8 +34,7 @@ export function parseSync(arrayBuffer, options = {}) {
   // Return pure javascript object
   const {byteOffset = 0} = options;
   const gltf = {};
-  parseGLTFSync(gltf, arrayBuffer, byteOffset, options);
-  return gltf;
+  return parseGLTFSync(gltf, arrayBuffer, byteOffset, options);
 }
 
 export default {

--- a/modules/gltf/src/lib/extensions/KHR_draco_mesh_compression.js
+++ b/modules/gltf/src/lib/extensions/KHR_draco_mesh_compression.js
@@ -1,111 +1,140 @@
+// https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_draco_mesh_compression
+// Only TRIANGLES: 0x0004 and TRIANGLE_STRIP: 0x0005 are supported
+
 /* eslint-disable camelcase */
 import GLTFScenegraph from '../gltf-scenegraph';
 import {KHR_DRACO_MESH_COMPRESSION} from '../gltf-constants';
 import {getGLTFAccessors, getGLTFAccessor} from '../gltf-utils/gltf-attribute-utils';
+import {parse} from '@loaders.gl/core';
 
 export default class KHR_draco_mesh_compression {
   static get name() {
     return KHR_DRACO_MESH_COMPRESSION;
   }
 
-  static decode(gltfData, options) {
-    const gltfScenegraph = new GLTFScenegraph(gltfData);
-
-    for (const mesh of gltfScenegraph.json.meshes || []) {
-      // eslint-disable-next-line camelcase
-      KHR_draco_mesh_compression.decompressMesh(mesh, options);
+  // Note: We have a "soft dependency" on Draco to avoid bundling it when not needed
+  static async decode(gltfData, options = {}) {
+    if (!options.decompress) {
+      return;
     }
 
-    // We have now decompressed all primitives, we can remove the top-level extensions
-    gltfScenegraph.removeExtension(KHR_DRACO_MESH_COMPRESSION);
-  }
-
-  static encode(gltfData, options) {
-    const gltfScenegraph = new GLTFScenegraph(gltfData);
-
-    for (const mesh of gltfScenegraph.json.meshes || []) {
-      // eslint-disable-next-line camelcase
-      KHR_draco_mesh_compression.compressMesh(mesh, options);
-      // NOTE: We only add if something was actually compressed
-      gltfScenegraph.addRequiredExtension(KHR_DRACO_MESH_COMPRESSION);
-    }
-  }
-
-  // eslint-disable-next-line max-len
-  // https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_draco_mesh_compression
-  // Only TRIANGLES: 0x0004 and TRIANGLE_STRIP: 0x0005 are supported
-  static compressMesh(attributes, indices, mode = 4, options = {}) {
-    if (!options.DracoWriter || !options.DracoLoader) {
-      throw new Error('DracoWriter/DracoLoader not available');
-    }
-
-    const compressedData = options.DracoWriter.encodeSync({attributes});
-
-    // Draco compression may change the order and number of vertices in a mesh.
-    // To satisfy the requirement that accessors properties be correct for both
-    // compressed and uncompressed data, generators should create uncompressed
-    // attributes and indices using data that has been decompressed from the Draco buffer,
-    // rather than the original source data.
-    const decodedData = options.DracoLoader.parseSync({attributes});
-    const fauxAccessors = options._addFauxAttributes(decodedData.attributes);
-
-    const bufferViewIndex = options.addBufferView(compressedData);
-
-    const glTFMesh = {
-      primitives: [
-        {
-          attributes: fauxAccessors, // TODO - verify with spec
-          mode, // GL.POINTS
-          extensions: {
-            [KHR_DRACO_MESH_COMPRESSION]: {
-              bufferView: bufferViewIndex,
-              attributes: fauxAccessors // TODO - verify with spec
-            }
-          }
-        }
-      ]
-    };
-
-    return glTFMesh;
-  }
-
-  static decompressMesh(mesh, options = {}) {
-    // We have a "soft dependency" on Draco to avoid bundling it when not needed
-    // DracoEncoder needs to be imported and supplied by app
-    // Decompress all the primitives in a mesh
-    for (const primitive of mesh.primitives) {
-      KHR_draco_mesh_compression._decompressMeshPrimitive(primitive, options);
-      if (!primitive.attributes || Object.keys(primitive.attributes).length === 0) {
-        throw new Error('Empty glTF primitive: decompression failure?');
+    const scenegraph = new GLTFScenegraph(gltfData);
+    const promises = [];
+    for (const primitive of meshPrimitiveIterator(scenegraph)) {
+      if (scenegraph.getObjectExtension(primitive, KHR_DRACO_MESH_COMPRESSION)) {
+        promises.push(decompressPrimitive(primitive, scenegraph, options));
       }
     }
+
+    // Decompress meshes in parallel
+    await Promise.all(promises);
+
+    // We have now decompressed all primitives, so remove the top-level extensions
+    scenegraph.removeExtension(KHR_DRACO_MESH_COMPRESSION);
   }
 
-  // Unpacks one mesh primitive and removes the extension from the primitive
-  // TODO - Implement fallback behavior per KHR_DRACO_MESH_COMPRESSION spec
-  // TODO - Decompression could be threaded: Use DracoWorkerLoader?
-  //
-  // eslint-disable-next-line max-len
-  // https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_draco_mesh_compression
-  static _decompressMeshPrimitive(primitive, options) {
-    const compressedPrimitive =
-      primitive.extensions && primitive.extensions[KHR_DRACO_MESH_COMPRESSION];
-    if (!compressedPrimitive) {
+  static decodeSync(gltfData, options) {
+    if (!options.decompress) {
       return;
     }
-
-    if (!options.DracoLoader || !options.decompress) {
-      return;
+    const scenegraph = new GLTFScenegraph(gltfData);
+    if (scenegraph.getRequiredExtension(KHR_DRACO_MESH_COMPRESSION)) {
+      throw new Error('Cannot synchronously decode Draco');
     }
+    // TODO - we can support sync decoding, let's just keep code/bundle size in check...
+  }
 
-    // Extension will be processed, delete it
-    delete primitive.extensions[KHR_DRACO_MESH_COMPRESSION];
+  static encode(gltfData, options = {}) {
+    const scenegraph = new GLTFScenegraph(gltfData);
 
-    const buffer = this._getBufferViewArray(compressedPrimitive.bufferView);
-    const decodedData = options.DracoLoader.parseSync(buffer);
-    primitive.attributes = getGLTFAccessors(decodedData.attributes);
-    if (decodedData.indices) {
-      primitive.indices = getGLTFAccessor(decodedData.indices);
+    for (const mesh of scenegraph.json.meshes || []) {
+      // eslint-disable-next-line camelcase
+      compressMesh(mesh, options);
+      // NOTE: Only add the extension if something was actually compressed
+      scenegraph.addRequiredExtension(KHR_DRACO_MESH_COMPRESSION);
+    }
+  }
+}
+
+// PRIVATE
+
+// Unpacks one mesh primitive and removes the extension from the primitive
+// DracoDecoder needs to be imported and registered by app
+// Returns: Promise that resolves when all pending draco decoder jobs for this mesh complete
+
+// TODO - Implement fallback behavior per KHR_DRACO_MESH_COMPRESSION spec
+
+async function decompressPrimitive(primitive, scenegraph, options) {
+  const compressedPrimitive = scenegraph.getObjectExtension(primitive, KHR_DRACO_MESH_COMPRESSION);
+
+  // eslint-disable-next-line
+  const buffer = scenegraph.getTypedArrayForBufferView(compressedPrimitive.bufferView);
+
+  // TODO - parse does not yet deal well with byte offsets embedded in typed arrays. Copy buffer
+  const subArray = new Uint8Array(buffer.buffer).subarray(buffer.byteOffset); // , buffer.byteLength);
+  const bufferCopy = new Uint8Array(subArray);
+
+  const decodedData = await parse(bufferCopy);
+
+  primitive.attributes = getGLTFAccessors(decodedData.attributes);
+  if (decodedData.indices) {
+    primitive.indices = getGLTFAccessor(decodedData.indices);
+  }
+
+  // Extension has been processed, delete it
+  // delete primitive.extensions[KHR_DRACO_MESH_COMPRESSION];
+
+  checkPrimitive(primitive);
+}
+
+// eslint-disable-next-line max-len
+// Only TRIANGLES: 0x0004 and TRIANGLE_STRIP: 0x0005 are supported
+function compressMesh(attributes, indices, mode = 4, options = {}) {
+  if (!options.DracoWriter || !options.DracoLoader) {
+    throw new Error('DracoWriter/DracoLoader not available');
+  }
+
+  // TODO - use registered DracoWriter...
+  const compressedData = options.DracoWriter.encodeSync({attributes});
+
+  // Draco compression may change the order and number of vertices in a mesh.
+  // To satisfy the requirement that accessors properties be correct for both
+  // compressed and uncompressed data, generators should create uncompressed
+  // attributes and indices using data that has been decompressed from the Draco buffer,
+  // rather than the original source data.
+  const decodedData = options.DracoLoader.parseSync({attributes});
+  const fauxAccessors = options._addFauxAttributes(decodedData.attributes);
+
+  const bufferViewIndex = options.addBufferView(compressedData);
+
+  const glTFMesh = {
+    primitives: [
+      {
+        attributes: fauxAccessors, // TODO - verify with spec
+        mode, // GL.POINTS
+        extensions: {
+          [KHR_DRACO_MESH_COMPRESSION]: {
+            bufferView: bufferViewIndex,
+            attributes: fauxAccessors // TODO - verify with spec
+          }
+        }
+      }
+    ]
+  };
+
+  return glTFMesh;
+}
+
+function checkPrimitive(primitive) {
+  if (!primitive.attributes && Object.keys(primitive.attributes).length > 0) {
+    throw new Error('Empty glTF primitive detected: Draco decompression failure?');
+  }
+}
+
+function* meshPrimitiveIterator(scenegraph) {
+  for (const mesh of scenegraph.json.meshes || []) {
+    for (const primitive of mesh.primitives) {
+      yield primitive;
     }
   }
 }

--- a/modules/gltf/src/lib/extensions/extensions.js
+++ b/modules/gltf/src/lib/extensions/extensions.js
@@ -1,0 +1,32 @@
+/* eslint-disable camelcase */
+import KHR_draco_mesh_compression from './KHR_draco_mesh_compression';
+import KHR_lights_punctual from './KHR_lights_punctual';
+// import UBER_POINT_CLOUD_COMPRESSION from './KHR_draco_mesh_compression';
+
+export const EXTENSIONS = {
+  KHR_draco_mesh_compression,
+  KHR_lights_punctual
+};
+
+export async function decodeExtensions(gltf, options) {
+  for (const extensionName in EXTENSIONS) {
+    const disableExtension = extensionName in options && !options[extensionName];
+    if (!disableExtension) {
+      const extension = EXTENSIONS[extensionName];
+      // Note: We decode extensions sequentially, this might not be necessary
+      // Currently we only have glTF, but when we add Basis we may revisit
+      await extension.decode(gltf, options);
+      // TODO - warn if extension cannot be decoded synchronously?
+    }
+  }
+}
+
+export function decodeExtensionsSync(gltf, options) {
+  for (const extensionName in EXTENSIONS) {
+    const disableExtension = extensionName in options && !options[extensionName];
+    if (!disableExtension) {
+      const extension = EXTENSIONS[extensionName];
+      extension.decodeSync(gltf, options);
+    }
+  }
+}

--- a/modules/gltf/src/lib/gltf-scenegraph.js
+++ b/modules/gltf/src/lib/gltf-scenegraph.js
@@ -22,11 +22,13 @@ export default class GLTFScenegraph {
           version: 2,
           buffers: []
         },
-        binary: null
+        buffers: []
       };
     }
 
+    // TODO - this is too sloppy, define inputs more clearly
     this.gltf = gltf;
+    assert(this.gltf.json);
   }
 
   // Accessors
@@ -124,9 +126,9 @@ export default class GLTFScenegraph {
     if (typeof index === 'object') {
       return index;
     }
-    const object = this.gltf[array] && this.gltf[array][index];
+    const object = this.json[array] && this.json[array][index];
     if (!object) {
-      console.warn(`glTF file error: Could not find ${array}[${index}]`); // eslint-disable-line
+      throw new Error(`glTF file error: Could not find ${array}[${index}]`); // eslint-disable-line
     }
     return object;
   }
@@ -135,11 +137,15 @@ export default class GLTFScenegraph {
   // returns a `Uint8Array`
   getTypedArrayForBufferView(bufferView) {
     bufferView = this.getBufferView(bufferView);
-    const buffer = this.getBuffer(bufferView.buffer);
-    const arrayBuffer = buffer.data;
+    const bufferIndex = bufferView.buffer;
 
-    const byteOffset = bufferView.byteOffset || 0;
-    return new Uint8Array(arrayBuffer, byteOffset, bufferView.byteLength);
+    // Get hold of the arrayBuffer
+    // const buffer = this.getBuffer(bufferIndex);
+    const binChunk = this.gltf.buffers[bufferIndex];
+    assert(binChunk);
+
+    const byteOffset = bufferView.byteOffset || 0 + binChunk.byteOffset;
+    return new Uint8Array(binChunk.arrayBuffer, byteOffset, bufferView.byteLength);
   }
 
   // accepts accessor index or accessor object

--- a/modules/gltf/src/lib/parse-glb.js
+++ b/modules/gltf/src/lib/parse-glb.js
@@ -13,12 +13,12 @@ const GLB_CHUNK_TYPE_BIN = 0x004e4942;
 const LE = true; // Binary GLTF is little endian.
 const BE = false; // Magic needs to be written as BE
 
-function getMagicString(dataView) {
+function getMagicString(dataView, byteOffset = 0) {
   return `\
-${String.fromCharCode(dataView.getUint8(0))}\
-${String.fromCharCode(dataView.getUint8(1))}\
-${String.fromCharCode(dataView.getUint8(2))}\
-${String.fromCharCode(dataView.getUint8(3))}`;
+${String.fromCharCode(dataView.getUint8(byteOffset + 0))}\
+${String.fromCharCode(dataView.getUint8(byteOffset + 1))}\
+${String.fromCharCode(dataView.getUint8(byteOffset + 2))}\
+${String.fromCharCode(dataView.getUint8(byteOffset + 3))}`;
 }
 
 // Check if a data view is a GLB
@@ -31,88 +31,148 @@ export function isGLB(arrayBuffer, byteOffset = 0, options = {}) {
 }
 
 // https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#glb-file-format-specification
+
+// Compare with GLB loader documentation
 /*
 Returns {
-  // Header
-  type: String,
-  magic: number,
+  header: {
+    type: string,
+    magic: number,
+    byteLength: number,
+    byteOffset: number
+  },
+
   version: number,
-  byteLength: number,
-  byteOffset: number,
 
   // JSON Chunk
   json: any,
 
   // BIN Chunk
   hasBinChunk: boolean,
+  binChunks: [{
+    arrayBuffer,
+    byteOffset,
+    byteLength
+  }],
+
+  // Deprecated (duplicates header)
+  type: string,
+  magic: number,
+  version: number,
+  byteLength: number,
+  byteOffset: number,
   binChunkByteOffset: number,
   binChunkLength: number
 }
 */
+
 export default function parseGLBSync(glb, arrayBuffer, byteOffset = 0, options = {}) {
   // Check that GLB Header starts with the magic number
   const dataView = new DataView(arrayBuffer);
 
-  glb.byteOffset = byteOffset; // Byte offset into the initial arrayBuffer
-
-  // GLB Header
-  glb.magic = dataView.getUint32(byteOffset + 0, BE); // Magic number (the ASCII string 'glTF').
+  glb.type = getMagicString(dataView, byteOffset + 0);
   glb.version = dataView.getUint32(byteOffset + 4, LE); // Version 2 of binary glTF container format
-  glb.byteLength = dataView.getUint32(byteOffset + 8, LE); // Total byte length of generated file
+  const byteLength = dataView.getUint32(byteOffset + 8, LE); // Total byte length of generated file
 
-  glb.type = getMagicString(dataView);
+  // Less important stuff in a header
+  glb.header = {
+    byteOffset, // Byte offset into the initial arrayBuffer
+    byteLength
+  };
 
-  // TODO - switch type checks to use strings
-  const {magic = MAGIC_glTF} = options;
-  const isMagicValid = glb.magic === MAGIC_glTF || glb.magic === magic;
-  if (!isMagicValid) {
+  if (glb.type !== 'glTF') {
     console.warn(`Invalid GLB magic string ${glb.type}`); // eslint-disable-line
   }
 
   assert(glb.version === 2, `Invalid GLB version ${glb.version}. Only .glb v2 supported`);
-  assert(glb.byteLength > 20);
+  assert(glb.header.byteLength > GLB_FILE_HEADER_SIZE + GLB_CHUNK_HEADER_SIZE);
 
-  // TODO - per spec we must iterate over chunks, ignoring all except JSON and BIN
+  // Per spec we must iterate over chunks, ignoring all except JSON and BIN
+  glb.json = {};
+  glb.hasBinChunk = false;
+  glb.binChunks = [];
 
-  // Parse the JSON chunk
+  parseGLBChunksSync(glb, dataView, byteOffset + 12, options);
 
-  const jsonChunkLength = dataView.getUint32(byteOffset + 12, LE); // Byte length of json chunk
-  const jsonChunkFormat = dataView.getUint32(byteOffset + 16, LE); // Chunk format as uint32
+  // DEPRECATED - duplicate header fields in root of returned object
+  addDeprecatedFields(glb);
 
-  // Check JSON Chunk format (0 = Back compat)
-  const isJSONChunk = jsonChunkFormat === GLB_CHUNK_TYPE_JSON || jsonChunkFormat === 0;
-  assert(isJSONChunk, `JSON chunk format ${jsonChunkFormat}`);
+  return byteOffset + glb.header.byteLength;
+}
 
-  // Create a "view" of the binary encoded JSON data
-  const jsonChunkByteOffset = GLB_FILE_HEADER_SIZE + GLB_CHUNK_HEADER_SIZE; // First headers: 20 bytes
-  const jsonChunk = new Uint8Array(arrayBuffer, byteOffset + jsonChunkByteOffset, jsonChunkLength);
+function parseGLBChunksSync(glb, dataView, byteOffset, options) {
+  // Iterate as long as there is space left for another chunk header
+  while (byteOffset + 8 <= glb.header.byteLength) {
+    const chunkLength = dataView.getUint32(byteOffset + 0, LE); // Byte length of chunk
+    const chunkFormat = dataView.getUint32(byteOffset + 4, LE); // Chunk format as uint32
+    byteOffset += GLB_CHUNK_HEADER_SIZE;
 
-  // Decode the JSON binary array into clear text
+    // Per spec we must iterate over chunks, ignoring all except JSON and BIN
+    switch (chunkFormat) {
+      case GLB_CHUNK_TYPE_JSON:
+        parseJSONChunk(glb, dataView, byteOffset, chunkLength, options);
+        break;
+      case GLB_CHUNK_TYPE_BIN:
+        parseBINChunk(glb, dataView, byteOffset, chunkLength, options);
+        break;
+      default:
+        // Ignore, per spec
+        // console.warn(`Unknown GLB chunk type`); // eslint-disable-line
+        break;
+    }
+
+    // DEPRECATED - Backward compatibility for very old xviz files
+    switch (chunkFormat) {
+      case 0:
+        if (!options.strict) {
+          parseJSONChunk(glb, dataView, byteOffset, chunkLength, options);
+        }
+        break;
+      case 1:
+        if (!options.strict) {
+          parseBINChunk(glb, dataView, byteOffset, chunkLength, options);
+        }
+        break;
+      default:
+    }
+
+    byteOffset += padTo4Bytes(chunkLength);
+  }
+
+  return byteOffset;
+}
+
+// Parse a GLB JSON chunk
+function parseJSONChunk(glb, dataView, byteOffset, chunkLength, options) {
+  // 1. Create a "view" of the binary encoded JSON data inside the GLB
+  const jsonChunk = new Uint8Array(dataView.buffer, byteOffset, chunkLength);
+
+  // 2. Decode the JSON binary array into clear text
   const textDecoder = new TextDecoder('utf8');
   const jsonText = textDecoder.decode(jsonChunk);
 
-  // Parse the JSON text into a JavaScript data structure
+  // 3. Parse the JSON text into a JavaScript data structure
   glb.json = JSON.parse(jsonText);
+}
 
-  const binChunkStart = jsonChunkByteOffset + padTo4Bytes(jsonChunkLength);
-
-  // Parse and check BIN chunk header
+// Parse a GLB BIN chunk
+function parseBINChunk(glb, dataView, byteOffset, chunkLength, options) {
   // Note: BIN chunk can be optional
-  glb.hasBinChunk = binChunkStart + 8 <= glb.byteLength;
+  glb.header.hasBinChunk = true;
+  glb.binChunks.push({
+    byteOffset,
+    byteLength: chunkLength,
+    arrayBuffer: dataView.buffer
+    // TODO - copy, or create typed array view?
+  });
+}
 
-  if (glb.hasBinChunk) {
-    const binChunkLength = dataView.getUint32(byteOffset + binChunkStart + 0, LE);
-    const binChunkFormat = dataView.getUint32(byteOffset + binChunkStart + 4, LE);
-
-    const isBinChunk = binChunkFormat === GLB_CHUNK_TYPE_BIN || binChunkFormat === 1; // Back compat
-    assert(isBinChunk, `BIN chunk format ${binChunkFormat}`);
-
-    const binChunkByteOffset = binChunkStart + GLB_CHUNK_HEADER_SIZE;
-
-    // TODO - copy or create typed array view
-    glb.binChunkByteOffset = binChunkByteOffset;
-    glb.binChunkLength = binChunkLength;
-  }
-
-  return byteOffset + glb.byteLength;
+function addDeprecatedFields(glb) {
+  glb.byteOffset = glb.header.byteOffset;
+  glb.magic = glb.header.magic;
+  glb.version = glb.header.version;
+  glb.byteLength = glb.header.byteLength;
+  glb.hasBinChunk = glb.binChunks.length >= 0;
+  glb.binChunkByteOffset = glb.header.hasBinChunk ? glb.binChunks[0].byteOffset : 0;
+  glb.binChunkLength = glb.header.hasBinChunk ? glb.binChunks[0].byteLength : 0;
 }

--- a/modules/gltf/src/lib/parse-glb.js
+++ b/modules/gltf/src/lib/parse-glb.js
@@ -11,7 +11,6 @@ const GLB_CHUNK_TYPE_JSON = 0x4e4f534a;
 const GLB_CHUNK_TYPE_BIN = 0x004e4942;
 
 const LE = true; // Binary GLTF is little endian.
-const BE = false; // Magic needs to be written as BE
 
 function getMagicString(dataView, byteOffset = 0) {
   return `\
@@ -172,7 +171,7 @@ function addDeprecatedFields(glb) {
   glb.magic = glb.header.magic;
   glb.version = glb.header.version;
   glb.byteLength = glb.header.byteLength;
-  glb.hasBinChunk = glb.binChunks.length >= 0;
+  glb.hasBinChunk = glb.binChunks.length >= 1;
   glb.binChunkByteOffset = glb.header.hasBinChunk ? glb.binChunks[0].byteOffset : 0;
   glb.binChunkLength = glb.header.hasBinChunk ? glb.binChunks[0].byteLength : 0;
 }

--- a/modules/gltf/test/lib/extensions/KHR_lights_punctual.spec.js
+++ b/modules/gltf/test/lib/extensions/KHR_lights_punctual.spec.js
@@ -51,7 +51,7 @@ const TEST_CASES = [
   }
 ];
 
-test('GLTF roundtrip#extensions', t => {
+test('gltf#KHR_lights_punctuals', t => {
   for (const testCase of TEST_CASES) {
     const json = getResolvedJson(testCase.input);
     t.deepEqual(json, testCase.output, testCase.name);

--- a/modules/gltf/test/lib/post-process-gltf.spec.js
+++ b/modules/gltf/test/lib/post-process-gltf.spec.js
@@ -30,7 +30,7 @@ const TEST_CASES = [
   }
 ];
 
-test('GLTF roundtrip#extensions', t => {
+test('gltf#postProcessGLTF', t => {
   for (const testCase of TEST_CASES) {
     const json = postProcessGLTF(testCase.input);
     t.deepEqual(json, testCase.output, testCase.name);


### PR DESCRIPTION
This is a round of improvements to the new gltf parser that will become default in loaders.gl v2.

Note that the deprecated gltf v1 parser is still the default when using `GLTFLoader`, so this change should be fairly low risk.