### PR TITLE
core: Fix binary test for typed arrays

### DIFF
--- a/modules/core/src/lib/select-loader.js
+++ b/modules/core/src/lib/select-loader.js
@@ -82,7 +82,12 @@ function findLoaderByExamingInitialData(loaders, data) {
         return loader;
       }
     } else if (data instanceof ArrayBuffer) {
-      if (testBinary(data, loader)) {
+      const byteOffset = 0;
+      if (testBinary(data, byteOffset, loader)) {
+        return loader;
+      }
+    } else if (ArrayBuffer.isView(data)) {
+      if (testBinary(data.buffer, data.byteOffset, loader)) {
         return loader;
       }
     }
@@ -95,7 +100,7 @@ function testText(data, loader) {
   return loader.testText && loader.testText(data);
 }
 
-function testBinary(data, loader) {
+function testBinary(data, byteOffset, loader) {
   const type = Array.isArray(loader.test) ? 'array' : typeof loader.test;
   switch (type) {
     case 'function':
@@ -105,9 +110,7 @@ function testBinary(data, loader) {
     case 'array':
       // Magic bytes check: If `loader.test` is a string or array of strings,
       // check if binary data starts with one of those strings
-      const byteOffset = 0;
       const tests = Array.isArray(loader.test) ? loader.test : [loader.test];
-
       return tests.some(test => {
         const magic = getMagicString(data, byteOffset, test.length);
         return test === magic;

--- a/modules/core/src/lib/select-loader.js
+++ b/modules/core/src/lib/select-loader.js
@@ -81,13 +81,14 @@ function findLoaderByExamingInitialData(loaders, data) {
       if (testText(data, loader)) {
         return loader;
       }
+    } else if (ArrayBuffer.isView(data)) {
+      // Typed Arrays can have offsets into underlying buffer
+      if (testBinary(data.buffer, data.byteOffset, loader)) {
+        return loader;
+      }
     } else if (data instanceof ArrayBuffer) {
       const byteOffset = 0;
       if (testBinary(data, byteOffset, loader)) {
-        return loader;
-      }
-    } else if (ArrayBuffer.isView(data)) {
-      if (testBinary(data.buffer, data.byteOffset, loader)) {
         return loader;
       }
     }

--- a/modules/core/test/lib/select-loader.spec.js
+++ b/modules/core/test/lib/select-loader.spec.js
@@ -15,7 +15,7 @@ test('selectLoader#urls', async t => {
   t.throws(() => selectLoader(null), 'selectedLoader throws if no loader found');
 
   t.equal(
-    selectLoader(null, '.', null, { nothrow: true }),
+    selectLoader(null, '.', null, {nothrow: true}),
     null,
     'selectedLoader({nothrow: true}) returns null instead of throwing'
   );
@@ -65,7 +65,7 @@ test('selectLoader#data', async t => {
   t.throws(() => selectLoader([KMLLoader], null, '{}'), 'find no loaders by examining text data');
 
   // Create an ArrayBuffer with a byteOffset to the payload
-  const byteOffset = 10
+  const byteOffset = 10;
   const offsetBuffer = new ArrayBuffer(tileData.byteLength + byteOffset);
   const offsetArray = new Uint8Array(offsetBuffer, byteOffset);
   offsetArray.set(new Uint8Array(tileData));

--- a/modules/core/test/lib/select-loader.spec.js
+++ b/modules/core/test/lib/select-loader.spec.js
@@ -11,17 +11,11 @@ import KML_SAMPLE from '@loaders.gl/kml/test/data/KML_Samples.kml';
 const DRACO_URL = '@loaders.gl/draco/test/data/bunny.drc';
 const TILE_3D_URL = '@loaders.gl/3d-tiles/test/data/PointCloud/PointCloudRGB/pointCloudRGB.pnts';
 
-test('parseSync#select-loader', async t => {
-  let response = await fetchFile(DRACO_URL);
-  const dracoData = await response.arrayBuffer();
-
-  response = await fetchFile(TILE_3D_URL);
-  const tileData = await response.arrayBuffer();
-
+test('selectLoader#urls', async t => {
   t.throws(() => selectLoader(null), 'selectedLoader throws if no loader found');
 
   t.equal(
-    selectLoader(null, '.', null, {nothrow: true}),
+    selectLoader(null, '.', null, { nothrow: true }),
     null,
     'selectedLoader({nothrow: true}) returns null instead of throwing'
   );
@@ -35,6 +29,14 @@ test('parseSync#select-loader', async t => {
     () => selectLoader([Tile3DLoader, DracoLoader, LASLoader], 'data.obj', null),
     'find no loaders by url extension'
   );
+});
+
+test('selectLoader#data', async t => {
+  let response = await fetchFile(DRACO_URL);
+  const dracoData = await response.arrayBuffer();
+
+  response = await fetchFile(TILE_3D_URL);
+  const tileData = await response.arrayBuffer();
 
   t.is(
     selectLoader([Tile3DLoader, DracoLoader, LASLoader], null, dracoData),
@@ -61,6 +63,17 @@ test('parseSync#select-loader', async t => {
     'find loader by examining text data'
   );
   t.throws(() => selectLoader([KMLLoader], null, '{}'), 'find no loaders by examining text data');
+
+  // Create an ArrayBuffer with a byteOffset to the payload
+  const byteOffset = 10
+  const offsetBuffer = new ArrayBuffer(tileData.byteLength + byteOffset);
+  const offsetArray = new Uint8Array(offsetBuffer, byteOffset);
+  offsetArray.set(new Uint8Array(tileData));
+  t.is(
+    selectLoader([Tile3DLoader], null, offsetArray),
+    Tile3DLoader,
+    'find loader by checking magic string in embedded tile data (with offset)'
+  );
 
   t.end();
 });


### PR DESCRIPTION
- Typed arrays can have offset which must be observed
- Needed to handle embedded binary formats efficiently (e.g. 3d-tiles with embedded glb payload)
- Broken out of #390 as this is the only core change that is not related to the optional v2 gltf parser.
