### PR TITLE
gltf: Add `options.gltf.parserVersion`

### DIFF
--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -4,26 +4,32 @@
 
 Target Release Date: Sep 13
 
-- `@loaders.gl/core`: **Worker Thread Pool**
-    - Reuses workers. Performance gains by avoiding worker startup overhead.
-    - Worker threads are named, easy to track in debugger
-    - Worker based loaders can now call `parse` recursively to parse embedded data
-
-- `@loaders.gl/core`: **Improved Format Auto-Discovery**
+- `@loaders.gl/core`: **Loader Selection Improvements**
     - The loader selection mechanism is now exposed to apps through the new `selectLoader` API.
     - Loaders can now examine the first bytes of a file
     - This complements the existing URL extension based auto detection mechanisms.
+
+- `@loaders.gl/core`: **Worker Thread Pool**
+    - Now reuses worker threads. Performance gains by avoiding worker startup overhead.
+    - Worker threads are named, easy to track in debugger
+    - Worker based loaders can now call `parse` recursively to delegate parsing of embedded data (e.g. glTF, Draco) to other loaders
+
+- `@loaders.gl/3d-tiles`: **Tile3DLayer moved to deck.gl**
+    - Tile3DLayer is now exported from `@deck.gl/geo-layers`
+
+- `@loaders.gl/3d-tiles`: **Batched 3D Model Tile Support**
+    - `b3dm` tilesets can now be loaded and displayed by the `Tile3DLayer`
 
 - `@loaders.gl/3d-tiles`: **RequestScheduler**
     - Cancels loads for not-yet loaded tiles that are no longer in view)
     - Dramatically improves loading performance when panning/zooming through a tileset
 
-- `@loaders.gl/3d-tiles`: **Automatic Timing**
-    - `Tileset3D` now contain a `stats` object with stats on the loading process.
+- `@loaders.gl/3d-tiles`: **Performance Tracking**
+    - `Tileset3D` now contain a `stats` object with stats on the loading process to help profile big tilesets.
 
 - `@loaders.gl/gltf`: **Version 2 Improvements**
     - Select the new glTF parser by passing `options.gltf.parserVersion: 2` to the `GLTFLoader`.
-    - Many bug fixes to the new glTF parser.
+    - Many improvements to the v2 glTF parser.
 
 ## v1.2
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -21,6 +21,9 @@ Target Release Date: Sep 13
 - `@loaders.gl/3d-tiles`: **Automatic Timing**
     - `Tileset3D` now contain a `stats` object with stats on the loading process.
 
+- `@loaders.gl/gltf`: **Version 2 Improvements**
+    - Select the new glTF parser by passing `options.gltf.parserVersion: 2` to the `GLTFLoader`.
+    - Many bug fixes to the new glTF parser.
 
 ## v1.2
 
@@ -56,12 +59,14 @@ Release Date: May 30, 2019
 
 ### @loaders.gl/gltf
 
-The glTF module has been refactored with the aim of simplifying the loaded data and orthogonalizing the API, as well as allowing 'embedded' GLB data inside other binary formats to be parsed (e.g. the glTF parser can now extract embedded glTF inside 3D tile files).
+- The glTF module has been refactored with the aim of simplifying the loaded data and orthogonalizing the API.
+- "Embedded' GLB data (GLBs inside other binary formats) can now be parsed (e.g. the glTF parser can now extract embedded glTF inside 3D tile files).
 
-- [`GLTFScenegraph`](/docs/api-reference/gltf/gltf-scenegraph) class <sup>NEW</sup> - A helper class that provides methods for structured access to and modification/creation of glTF data.
-- [`postProcessGLTF`](/docs/api-reference/gltf/post-process-gltf) function <sup>NEW</sup> - Function that performs a set of transformations on loaded glTF data that simplify application processing.
-- [`GLBLoader`](/docs/api-reference/gltf/glb-loader)/[`GLBWriter`] <sup>NEW</sup> - loader/writer pair that enables loading/saving custom (non-glTF) data in the binary GLB format.
-- [`GLTFLoader`](/docs/api-reference/gltf/gltf-loader), letting application separately handle post-processing etc.
+- New classes/functions:
+    - [`GLTFScenegraph`](/docs/api-reference/gltf/gltf-scenegraph) class <sup>NEW</sup> - A helper class that provides methods for structured access to and modification/creation of glTF data.
+    - [`postProcessGLTF`](/docs/api-reference/gltf/post-process-gltf) function <sup>NEW</sup> - Function that performs a set of transformations on loaded glTF data that simplify application processing.
+    - [`GLBLoader`](/docs/api-reference/gltf/glb-loader)/[`GLBWriter`] <sup>NEW</sup> - loader/writer pair that enables loading/saving custom (non-glTF) data in the binary GLB format.
+    - [`GLTFLoader`](/docs/api-reference/gltf/gltf-loader), letting application separately handle post-processing.
 
 ### @loaders.gl/3d-tiles <sup>NEW MODULE</sup>
 

--- a/examples/3d-tiles/app.js
+++ b/examples/3d-tiles/app.js
@@ -18,9 +18,10 @@ import ControlPanel from './components/control-panel';
 import fileDrop from './components/file-drop';
 
 import {loadExampleIndex} from './examples';
+import { registerLoaders } from '@loaders.gl/core';
 
-export const INITIAL_EXAMPLE_CATEGORY = 'ion';
-export const INITIAL_EXAMPLE_NAME = 'Mount St Helens (PointCloud)';
+const INITIAL_EXAMPLE_CATEGORY = 'ion';
+const INITIAL_EXAMPLE_NAME = 'Mount St Helens (PointCloud)';
 
 // Set your mapbox token here
 const MAPBOX_TOKEN = process.env.MapboxAccessToken; // eslint-disable-line
@@ -47,6 +48,8 @@ export const INITIAL_VIEW_STATE = {
   maxZoom: 30,
   zoom: 17
 };
+
+registerLoaders([DracoLoader]);
 
 export default class App extends PureComponent {
   constructor(props) {

--- a/examples/3d-tiles/app.js
+++ b/examples/3d-tiles/app.js
@@ -18,7 +18,7 @@ import ControlPanel from './components/control-panel';
 import fileDrop from './components/file-drop';
 
 import {loadExampleIndex} from './examples';
-import { registerLoaders } from '@loaders.gl/core';
+import {registerLoaders} from '@loaders.gl/core';
 
 const INITIAL_EXAMPLE_CATEGORY = 'ion';
 const INITIAL_EXAMPLE_NAME = 'Mount St Helens (PointCloud)';

--- a/examples/3d-tiles/tile-3d-layer/tile-3d-layer.js
+++ b/examples/3d-tiles/tile-3d-layer/tile-3d-layer.js
@@ -178,6 +178,7 @@ export default class Tile3DLayer extends CompositeLayer {
   _unpackGLTF(tileHeader) {
     if (tileHeader.content.gltfArrayBuffer) {
       tileHeader.userData.gltf = parse(tileHeader.content.gltfArrayBuffer, {
+        // gltf: {parserVersion: 2},
         DracoLoader: this.props.DracoLoader,
         decompress: true
       });

--- a/examples/gltf/app.js
+++ b/examples/gltf/app.js
@@ -28,7 +28,7 @@ import {
 import Controller from './controller';
 
 const DEFAULT_OPTIONS = {
-  useGLTFParser: true, // Use deprecated parser for now
+  gltf: {parserVersion: 1}, // Use deprecated parser for now
   pbrDebug: true,
   imageBasedLightingEnvironment: null,
   lights: false

--- a/examples/webpack.config.local.js
+++ b/examples/webpack.config.local.js
@@ -58,7 +58,7 @@ const LOCAL_DEVELOPMENT_CONFIG = {
   },
 
   resolve: {
-    mainFields: ['esnext', 'browser', 'module', 'main'],
+    // mainFields: ['esnext', 'browser', 'module', 'main'],
     // Imports the library from its src directory in this repo
     alias: Object.assign({}, ALIASES)
   },
@@ -100,7 +100,7 @@ function addLocalDependency(config, dependency) {
 function addLocalDevSettings(config, opts) {
   config = Object.assign({}, LOCAL_DEVELOPMENT_CONFIG, config);
   config.resolve = config.resolve || {};
-  config.resolve.mainFields = LOCAL_DEVELOPMENT_CONFIG.resolve.mainFields;
+  // config.resolve.mainFields = LOCAL_DEVELOPMENT_CONFIG.resolve.mainFields;
   config.resolve.alias = config.resolve.alias || {};
   Object.assign(config.resolve.alias, LOCAL_DEVELOPMENT_CONFIG.resolve.alias);
 

--- a/modules/gltf/src/gltf-loader.js
+++ b/modules/gltf/src/gltf-loader.js
@@ -5,7 +5,7 @@ import GLTFParser from './lib/deprecated/gltf-parser';
 
 const DEFAULT_OPTIONS = {
   gltf: {
-    useParserV2: false // if `true`, uses the new parser that will be the only option in V2.
+    parserVersion: 1 // the new parser that will be the only option in V2.
   },
   uri: '' // base URI
 };

--- a/modules/gltf/src/gltf-loader.js
+++ b/modules/gltf/src/gltf-loader.js
@@ -4,14 +4,17 @@ import {parseGLTFSync, parseGLTF} from './lib/parse-gltf';
 import GLTFParser from './lib/deprecated/gltf-parser';
 
 const DEFAULT_OPTIONS = {
-  useGLTFParser: true // GLTFParser will be removed in v2.
+  gltf: {
+    useParserV2: false // if `true`, uses the new parser that will be the only option in V2.
+  },
+  uri: '' // base URI
 };
 
 export async function parse(arrayBuffer, options = {}) {
   // Apps like to call the parse method directly so apply default options here
   options = {...DEFAULT_OPTIONS, ...options};
   // Deprecated: Return GLTFParser instance
-  if (options.useGLTFParser) {
+  if (options.gltf.parserVersion !== 2 && options.useGLTFParser !== false) {
     const gltfParser = new GLTFParser();
     return gltfParser.parse(arrayBuffer, options);
   }
@@ -27,7 +30,7 @@ export function parseSync(arrayBuffer, options = {}) {
   options = {...DEFAULT_OPTIONS, ...options};
 
   // Deprecated: Return GLTFParser instance
-  if (options.useGLTFParser) {
+  if (options.gltf.parserVersion !== 2 && options.useGLTFParser !== false) {
     return new GLTFParser().parseSync(arrayBuffer, options);
   }
 

--- a/modules/gltf/src/lib/parse-gltf.js
+++ b/modules/gltf/src/lib/parse-gltf.js
@@ -128,7 +128,12 @@ function parseGLTFContainerSync(gltf, data, byteOffset, options) {
 async function fetchBuffers(gltf, options) {
   for (let i = 0; i < gltf.json.buffers.length; ++i) {
     const buffer = gltf.json.buffers[i];
-    if (buffer.uri) {
+    // TODO - remove this defensive hack and auto-infer the base URI
+    if (!options.uri) {
+      // eslint-disable-next-line
+      console.warn('options.uri must be set to decode embedded glTF buffers');
+    }
+    if (buffer.uri && options.uri) {
       const fetch = options.fetch || window.fetch;
       assert(fetch);
       const uri = getFullUri(buffer.uri, options.uri);

--- a/modules/gltf/test/gltf-loader.spec.js
+++ b/modules/gltf/test/gltf-loader.spec.js
@@ -19,7 +19,7 @@ test('GLTFLoader#parseSync(text/JSON)', async t => {
   const data = await response.text();
 
   t.throws(
-    () => parseSync(data, GLTFLoader, { gltf: { parserVersion: 2 } }),
+    () => parseSync(data, GLTFLoader, {gltf: {parserVersion: 2}}),
     'GLTFLoader throws when synchronously parsing gltfs with base64 buffers'
   );
 

--- a/modules/gltf/test/gltf-loader.spec.js
+++ b/modules/gltf/test/gltf-loader.spec.js
@@ -12,7 +12,45 @@ test('GLTFLoader#imports', t => {
   t.end();
 });
 
+// V2 parser
+
 test('GLTFLoader#parseSync(text/JSON)', async t => {
+  const response = await fetchFile(GLTF_JSON_URL);
+  const data = await response.text();
+
+  t.throws(
+    () => parseSync(data, GLTFLoader, { gltf: { parserVersion: 2 } }),
+    'GLTFLoader throws when synchronously parsing gltfs with base64 buffers'
+  );
+
+  t.end();
+});
+
+test('GLTFLoader#parseSync(binary)', async t => {
+  const response = await fetchFile(GLTF_BINARY_URL);
+  const data = await response.arrayBuffer();
+
+  const gltf = parseSync(data, GLTFLoader, {gltf: {parserVersion: 2}});
+  t.ok(gltf, 'GLTFLoader returned parsed data');
+
+  t.end();
+});
+
+test('GLTFLoader#load(binary)', async t => {
+  const data = await load(GLTF_BINARY_URL, GLTFLoader, {gltf: {parserVersion: 2}});
+  t.ok(data.json.asset, 'GLTFLoader returned parsed data');
+  t.end();
+});
+
+test('GLTFLoader#load(text)', async t => {
+  const data = await load(GLTF_JSON_URL, GLTFLoader, {gltf: {parserVersion: 2}});
+  t.ok(data.json.asset, 'GLTFLoader returned parsed data');
+  t.end();
+});
+
+// V1 parser (deprecated)
+
+test('GLTFLoader#parseSync(text/JSON) V1', async t => {
   const response = await fetchFile(GLTF_JSON_URL);
   const data = await response.text();
 
@@ -22,7 +60,7 @@ test('GLTFLoader#parseSync(text/JSON)', async t => {
   t.end();
 });
 
-test('GLTFLoader#parseSync(binary)', async t => {
+test('GLTFLoader#parseSync(binary) V1', async t => {
   const response = await fetchFile(GLTF_BINARY_URL);
   const data = await response.arrayBuffer();
 
@@ -32,13 +70,13 @@ test('GLTFLoader#parseSync(binary)', async t => {
   t.end();
 });
 
-test('GLTFLoader#load(binary)', async t => {
+test('GLTFLoader#load(binary) V1', async t => {
   const data = await load(GLTF_BINARY_URL, GLTFLoader);
   t.ok(data.asset, 'GLTFLoader returned parsed data');
   t.end();
 });
 
-test('GLTFLoader#load(text)', async t => {
+test('GLTFLoader#load(text) V1', async t => {
   const data = await load(GLTF_JSON_URL, GLTFLoader);
   t.ok(data.asset, 'GLTFLoader returned parsed data');
   t.end();

--- a/modules/gltf/test/gltf-writer.spec.js
+++ b/modules/gltf/test/gltf-writer.spec.js
@@ -60,7 +60,7 @@ test('GLTFWriter#encode (DEPRECATED settings)', t => {
   const arrayBuffer = gltfBuilder.encodeSync();
 
   const gltf = parseSync(arrayBuffer, GLTFLoader, {gltf: {parserVersion: 2}});
-  const gltfScenegraph = new GLTFScenegraph({json: gltf});
+  const gltfScenegraph = new GLTFScenegraph(gltf);
 
   const appData = gltfScenegraph.getApplicationData('viz');
   const extraData = gltfScenegraph.getExtraData('test');

--- a/modules/gltf/test/gltf-writer.spec.js
+++ b/modules/gltf/test/gltf-writer.spec.js
@@ -23,9 +23,9 @@ test('GLTFWriter#encode', t => {
   gltfBuilder.addExtension(USED_EXTENSION_2, EXTENSION_DATA_1);
   gltfBuilder.addRequiredExtension(REQUIRED_EXTENSION_2, EXTENSION_DATA_2);
 
-  const arrayBuffer = encodeSync(gltfBuilder.gltf, GLTFWriter, { gltf: { parserVersion: 2 } });
+  const arrayBuffer = encodeSync(gltfBuilder.gltf, GLTFWriter, {gltf: {parserVersion: 2}});
 
-  const gltf = parseSync(arrayBuffer, GLTFLoader, { gltf: { parserVersion: 2 } });
+  const gltf = parseSync(arrayBuffer, GLTFLoader, {gltf: {parserVersion: 2}});
   const gltfScenegraph = new GLTFScenegraph(gltf);
 
   const appData = gltfScenegraph.getApplicationData('viz');

--- a/modules/gltf/test/gltf-writer.spec.js
+++ b/modules/gltf/test/gltf-writer.spec.js
@@ -59,7 +59,7 @@ test('GLTFWriter#encode (DEPRECATED settings)', t => {
 
   const arrayBuffer = gltfBuilder.encodeSync();
 
-  const gltf = parseSync(arrayBuffer, GLTFLoader, {gltf: {useParserV2: true}});
+  const gltf = parseSync(arrayBuffer, GLTFLoader, {gltf: {parserVersion: 2}});
   const gltfScenegraph = new GLTFScenegraph({json: gltf});
 
   const appData = gltfScenegraph.getApplicationData('viz');

--- a/modules/gltf/test/gltf-writer.spec.js
+++ b/modules/gltf/test/gltf-writer.spec.js
@@ -23,9 +23,9 @@ test('GLTFWriter#encode', t => {
   gltfBuilder.addExtension(USED_EXTENSION_2, EXTENSION_DATA_1);
   gltfBuilder.addRequiredExtension(REQUIRED_EXTENSION_2, EXTENSION_DATA_2);
 
-  const arrayBuffer = encodeSync(gltfBuilder.gltf, GLTFWriter, {useGLTFBuilder: false});
+  const arrayBuffer = encodeSync(gltfBuilder.gltf, GLTFWriter, { gltf: { parserVersion: 2 } });
 
-  const gltf = parseSync(arrayBuffer, GLTFLoader, {useGLTFParser: false});
+  const gltf = parseSync(arrayBuffer, GLTFLoader, { gltf: { parserVersion: 2 } });
   const gltfScenegraph = new GLTFScenegraph(gltf);
 
   const appData = gltfScenegraph.getApplicationData('viz');
@@ -59,7 +59,7 @@ test('GLTFWriter#encode (DEPRECATED settings)', t => {
 
   const arrayBuffer = gltfBuilder.encodeSync();
 
-  const gltf = parseSync(arrayBuffer, GLTFLoader, {useGLTFParser: true});
+  const gltf = parseSync(arrayBuffer, GLTFLoader, {gltf: {useParserV2: true}});
   const gltfScenegraph = new GLTFScenegraph({json: gltf});
 
   const appData = gltfScenegraph.getApplicationData('viz');


### PR DESCRIPTION
Add `gltf.parserVersion` option to enable clear selection of new v2 gltf parser.

V2 parser is gradually being phased in as remaining bugs are ironed out.