### PR TITLE
3d-tiles: Use unique string for the key in layerMap

### DIFF
--- a/examples/3d-tiles/tile-3d-layer/tile-3d-layer.js
+++ b/examples/3d-tiles/tile-3d-layer/tile-3d-layer.js
@@ -111,7 +111,7 @@ export default class Tile3DLayer extends CompositeLayer {
     const {tileset3d, layerMap} = this.state;
     const {selectedTiles} = tileset3d;
 
-    const tilesWithoutLayer = selectedTiles.filter(tile => !layerMap[tile.contentUri]);
+    const tilesWithoutLayer = selectedTiles.filter(tile => !layerMap[tile.fullUri]);
 
     for (const tile of tilesWithoutLayer) {
       // TODO - why do we call this here? Being "selected" should automatically add it to cache?
@@ -119,7 +119,7 @@ export default class Tile3DLayer extends CompositeLayer {
 
       this._unpackTile(tile);
 
-      layerMap[tile.contentUri] = {
+      layerMap[tile.fullUri] = {
         layer: this._create3DTileLayer(tile),
         tile
       };
@@ -140,16 +140,16 @@ export default class Tile3DLayer extends CompositeLayer {
         if (layer && layer.props && !layer.props.visible) {
           // Still has GPU resource but visibility is turned off so turn it back on so we can render it.
           layer = layer.clone({visible: true});
-          layerMap[tile.contentUri].layer = layer;
+          layerMap[tile.fullUri].layer = layer;
         }
         selectedLayers.push(layer);
       } else if (tile.contentUnloaded) {
         // Was cleaned up from tileset cache. We no longer need to track it.
-        delete layerMap[tile.contentUri];
+        delete layerMap[tile.fullUri];
       } else if (layer && layer.props && layer.props.visible) {
         // Still in tileset cache but doesn't need to render this frame. Keep the GPU resource bound but don't render it.
         layer = layer.clone({visible: false});
-        layerMap[tile.contentUri].layer = layer;
+        layerMap[tile.fullUri].layer = layer;
       }
     }
 
@@ -209,7 +209,7 @@ export default class Tile3DLayer extends CompositeLayer {
     const {instances, cartographicOrigin, modelMatrix} = tileHeader.content;
 
     return new ScenegraphLayer({
-      id: `3d-model-tile-layer-${tileHeader.contentUri}`,
+      id: `3d-model-tile-layer-${tileHeader.fullUri}`,
       data: instances || [{}],
       coordinateSystem: COORDINATE_SYSTEM.METER_OFFSETS,
       coordinateOrigin: cartographicOrigin,
@@ -241,7 +241,7 @@ export default class Tile3DLayer extends CompositeLayer {
     return (
       positions &&
       new PointCloudLayer({
-        id: `3d-point-cloud-tile-layer-${tileHeader.contentUri}`,
+        id: `3d-point-cloud-tile-layer-${tileHeader.fullUri}`,
         data: {
           header: {
             vertexCount: pointCount

--- a/modules/3d-tiles/src/tileset/tile-3d-header.js
+++ b/modules/3d-tiles/src/tileset/tile-3d-header.js
@@ -586,6 +586,7 @@ export default class Tile3DHeader {
       this._content = null;
       this.hasEmptyContent = false;
       this.contentState = TILE3D_CONTENT_STATE.UNLOADED;
+      this.fullUri = this._basePath + '/' + this.contentUri;
       // this.serverKey = RequestScheduler.getServerKey(contentResource.getUrlComponent());
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6898,10 +6898,10 @@ octokit-pagination-methods@^1.1.0:
   resolved "https://registry.yarnpkg.com/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz#cf472edc9d551055f9ef73f6e42b4dbb4c80bea4"
   integrity sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ==
 
-ocular-dev-tools@0.0.27:
-  version "0.0.27"
-  resolved "https://registry.yarnpkg.com/ocular-dev-tools/-/ocular-dev-tools-0.0.27.tgz#6d66ab938c404ba37ff910c3f80817d099a72782"
-  integrity sha512-OrKiIfiku6a1PmzZS9ahBVXPK3i1v9zDeKoSXwar4esglyUrU7nOpV9hd2qZ+c00AcDlyH28y0i9pIWqpZQZJA==
+ocular-dev-tools@0.0.29:
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/ocular-dev-tools/-/ocular-dev-tools-0.0.29.tgz#7492858c6582ae1772a82725ade6d3918e8cb1ce"
+  integrity sha512-fis0mt4nL/6xUdEbAkihw0yNN2lONgcxM0W3mE+a79xAy+syEW/adZqeagdCtXfACspb3CX5F5R5ULbJituzWA==
   dependencies:
     "@babel/cli" "^7.0.0"
     "@babel/core" "^7.0.0"
@@ -6913,8 +6913,11 @@ ocular-dev-tools@0.0.27:
     eslint "^4.13.1"
     eslint-config-prettier "^2.9.0"
     eslint-config-uber-es2015 "^3.0.0"
+    handlebars "^4.1.2"
     html-webpack-plugin "^3.2.0"
     lerna "^3.14.1"
+    lodash "^4.17.13"
+    lodash.template "^4.5.0"
     module-alias "^2.0.0"
     nyc "^13.3.0"
     prettier "1.14.3"


### PR DESCRIPTION
The problem is contentUri is a relative to a tileset's base path so it won't be unique identifier in the layerMap. During tile construction we can save off the the full uri and use that as the unique string id for the layerMap. 