### PR TITLE
docs: Bring arrow docs into loaders.gl website

### DIFF
--- a/docs/specifications/loader-object-format.md
+++ b/docs/specifications/loader-object-format.md
@@ -23,7 +23,7 @@ Note: Only one of `extension` or `extensions` is required. If both are supplied,
 | `test`     | `Function` | `String` | `String[]`                                                                                    | `null` | Guesses if a binary format file is of this format by examining the first bytes in the file. If the test is specified as a string or array of strings, the initial bytes are expected to be "magic bytes" matching one of the provided strings. |
 | `testText` | `Function` | `null`   | Guesses if a text format file is of this format by examining the first characters in the file |
 
-### Parser Function
+### Parser Functions
 
 Each (non-worker) loader should define a `parse` function. Additional parsing functions can be exposed depending on the loaders capabilities, to optimize for text parsing, synchronous parsing, streaming parsing, etc:
 

--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -185,6 +185,65 @@
           ]
         }
       ]
+    },
+
+    {
+      "title": "Arrow JS",
+      "chapters": [
+        {
+          "title": "Overview",
+          "entries": [
+            {"entry": "arrowjs/docs"},
+            {"entry": "arrowjs/docs/roadmap"},
+            {"entry": "arrowjs/docs/contributing"}
+          ]
+        },
+        {
+          "title": "Get Started",
+          "entries": [
+            {"entry": "arrowjs/docs/get-started/installing"},
+            {"entry": "arrowjs/docs/get-started/examples"}
+          ]
+        },
+        {
+          "title": "Developer Guide",
+          "entries": [
+            {"entry": "arrowjs/docs/developer-guide/big-ints"},
+            {"entry": "arrowjs/docs/developer-guide/converting-data"},
+            {"entry": "arrowjs/docs/developer-guide/data-frame-operations"},
+            {"entry": "arrowjs/docs/developer-guide/data-sources"},
+            {"entry": "arrowjs/docs/developer-guide/data-types"},
+            {"entry": "arrowjs/docs/developer-guide/memory-management"},
+            {"entry": "arrowjs/docs/developer-guide/predicates"},
+            {"entry": "arrowjs/docs/developer-guide/reading-and-writing"},
+            {"entry": "arrowjs/docs/developer-guide/tables"},
+            {"entry": "arrowjs/docs/developer-guide/typescript"}
+          ]
+        },
+        {
+          "title": "API Reference",
+          "entries": [
+            {"entry": "arrowjs/docs/api-reference"},
+            {"entry": "arrowjs/docs/api-reference/chunked"},
+            {"entry": "arrowjs/docs/api-reference/column"},
+            {"entry": "arrowjs/docs/api-reference/data-frame"},
+            {"entry": "arrowjs/docs/api-reference/data"},
+            {"entry": "arrowjs/docs/api-reference/dictionary"},
+            {"entry": "arrowjs/docs/api-reference/field"},
+            {"entry": "arrowjs/docs/api-reference/predicates"},
+            {"entry": "arrowjs/docs/api-reference/record-batch-reader"},
+            {"entry": "arrowjs/docs/api-reference/record-batch-writer"},
+            {"entry": "arrowjs/docs/api-reference/record-batch"},
+            {"entry": "arrowjs/docs/api-reference/row"},
+            {"entry": "arrowjs/docs/api-reference/schema"},
+            {"entry": "arrowjs/docs/api-reference/table"},
+            {"entry": "arrowjs/docs/api-reference/types"},
+            {"entry": "arrowjs/docs/api-reference/vector"},
+            {"entry": "arrowjs/docs/api-reference/vectors"}
+          ]
+        }
+      ]
     }
+
   ]
 }

--- a/website/gatsby-config.js
+++ b/website/gatsby-config.js
@@ -17,6 +17,7 @@ gatsbyConfig.plugins.forEach(plugin => {
     plugin.options.ignore.push('**/modules/**/dist');
     plugin.options.ignore.push('**/modules/**/wip');
     plugin.options.ignore.push('**/modules/**/*.json');
+    plugin.options.ignore.push('**/arrowjs/**/*.json');
   }
 });
 

--- a/website/ocular-config.js
+++ b/website/ocular-config.js
@@ -17,9 +17,10 @@ for (const dependency in DEPENDENCIES) {
 }
 
 module.exports = {
-  logLevel: 4, // Adjusts amount of debug information from ocular-gatsby
+  logLevel: 2, // Adjusts amount of debug information from ocular-gatsby
 
-  DOC_FOLDERS: [`${__dirname}/../docs/`, `${__dirname}/../modules`],
+  // NOTE - we currently need custom excludes in gatsby-config.js to support multiple directories
+  DOC_FOLDERS: [`${__dirname}/../docs/`, `${__dirname}/../arrowjs/`, `${__dirname}/../modules/`],
   ROOT_FOLDER: `${__dirname}/../`,
   DIR_NAME: `${__dirname}`,
 


### PR DESCRIPTION
@trxcllnt 

Making sure the docs we wrote are hosted on loaders.gl. The previous nested site staging was quite fragile. Hopefully this will inspire us to make the "final push".

<img width="349" alt="Screen Shot 2019-09-16 at 1 25 34 PM" src="https://user-images.githubusercontent.com/7025232/64990848-7cf21280-d885-11e9-89d7-71a3452a4ac3.png">
