### PR TITLE
Fix full uri

### DIFF
--- a/modules/3d-tiles/src/lib/tileset/tileset-3d.js
+++ b/modules/3d-tiles/src/lib/tileset/tileset-3d.js
@@ -326,7 +326,7 @@ export default class Tileset3D {
     //   ? Axis.fromName(tilesetJson.asset.gltfUpAxis)
     //   : Axis.Y;
 
-    this._root = this._initializeTileHeaders(tilesetJson, null);
+    this._root = this._initializeTileHeaders(tilesetJson, null, this.basePath);
 
     // Calculate cartographicCenter & zoom props to help apps center view on tileset
     this._calculateViewProps();


### PR DESCRIPTION
`baseUri` is missing, so the tiles' `fullUri` ended up something like  

`undefined/0/0.b3dm`.
