### PR TITLE
examples: Enable debugging with non-transpiled async functions

### DIFF
--- a/examples/3d-tiles/package.json
+++ b/examples/3d-tiles/package.json
@@ -2,10 +2,10 @@
   "license": "MIT",
   "scripts": {
     "start": "webpack-dev-server --progress --hot --open",
-    "start-local": "webpack-dev-server --env.local --progress --hot --open",
-    "start-local-deck": "webpack-dev-server --env.local --env.deck --progress --hot --open",
-    "start-local-luma": "webpack-dev-server --env.local --env.luma --progress --hot --open",
-    "start-local-math": "webpack-dev-server --env.local --env.math --progress --hot --open",
+    "start-local": "webpack-dev-server --env.local --env.esnext --progress --hot --open",
+    "start-local-deck": "webpack-dev-server --env.local --env.esnext --env.deck --progress --hot --open",
+    "start-local-luma": "webpack-dev-server --env.local --env.esnext --env.luma --progress --hot --open",
+    "start-local-math": "webpack-dev-server --env.local --env.esnext --env.math --progress --hot --open",
     "generate": "node ./generate-index/index.js"
   },
   "dependencies": {

--- a/examples/gltf/package.json
+++ b/examples/gltf/package.json
@@ -5,7 +5,7 @@
   ],
   "scripts": {
     "start": "webpack-dev-server --progress --hot --open -d",
-    "start-local": "webpack-dev-server --env.local --progress --hot --open -d",
+    "start-local": "webpack-dev-server --env.local --env.esnext --progress --hot --open -d",
     "open-vr": "adb reverse tcp:8080 tcp:8080 && adb shell am start -a android.intent.action.VIEW -d http://localhost:8080/"
   },
   "dependencies": {


### PR DESCRIPTION
Maybe some of the webpack.config.local handling could go into ocular-dev-tools?