### PR TITLE
3d-tiles: Port Geodan THREE.js example

### DIFF
--- a/examples/3d-tiles-threejs/LICENSE
+++ b/examples/3d-tiles-threejs/LICENSE
@@ -1,0 +1,30 @@
+BSD 3-Clause License
+
+Copyright (c) 2019, Geodan
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/examples/3d-tiles-threejs/app.js
+++ b/examples/3d-tiles-threejs/app.js
@@ -1,0 +1,39 @@
+/* global mapboxgl */ // Imported via <script> tag
+import Mapbox3DTilesLayer from './mapbox-3d-tiles-layer/mapbox-3d-tiles-layer';
+
+// TODO - Add your mapbox token here
+mapboxgl.accessToken = process.env.MapboxAccessToken; // eslint-disable-line
+
+const BASE_TILESET_URL = 'https://raw.githubusercontent.com/uber-common/deck.gl-data/master';
+const ROTTERDAM_TILESET_URL = `${BASE_TILESET_URL}/3d-tiles/geodan/rotterdam/tileset.json`;
+const AHN_TILESET_URL = `${BASE_TILESET_URL}/3d-tiles/geodan/ahn/tileset.json`;
+
+// Load the mapbox map
+const map = new mapboxgl.Map({
+  container: 'map',
+  style: 'mapbox://styles/mapbox/dark-v10?optimize=true',
+  center: [4.48732, 51.90217],
+  zoom: 14.3,
+  bearing: 0,
+  pitch: 45,
+  hash: true
+});
+
+map.on('style.load', function() {
+  const rotterdam = new Mapbox3DTilesLayer({
+    id: 'rotterdam',
+    url: ROTTERDAM_TILESET_URL,
+    color: 0x0033aa,
+    opacity: 0.5
+  });
+  map.addLayer(rotterdam, 'waterway-label');
+
+  const ahn = new Mapbox3DTilesLayer({
+    id: 'ahn',
+    url: AHN_TILESET_URL,
+    color: 0x007722,
+    opacity: 1.0,
+    pointsize: 1.0
+  });
+  map.addLayer(ahn, 'rotterdam');
+});

--- a/examples/3d-tiles-threejs/index.html
+++ b/examples/3d-tiles-threejs/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset='utf-8' />
+	<title>3DTile Layer for Mapbox GL JS</title>
+	<meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
+	<script src="./node_modules/mapbox-gl/dist/mapbox-gl.js"></script>
+	<link rel="stylesheet" type="text/css" href="./node_modules/mapbox-gl/dist/mapbox-gl.css">
+	<script src="./node_modules/three/build/three.min.js"></script>
+	<script src="./node_modules/three/examples/js/loaders/GLTFLoader.js"></script>
+	<style>
+		body { margin:0; padding:0; }
+		#map { position:absolute; top:0; bottom:0; width:100%; }
+		#controls { position:absolute; top:0; left:0; }
+	</style>
+</head>
+<body>
+	<div id='map'></div>
+	<script src="./app.js"></script>
+</body>
+</html>
+

--- a/examples/3d-tiles-threejs/mapbox-3d-tiles-layer/mapbox-3d-tiles-layer.js
+++ b/examples/3d-tiles-threejs/mapbox-3d-tiles-layer/mapbox-3d-tiles-layer.js
@@ -1,0 +1,120 @@
+import * as THREE from 'three';
+import {loadTileset} from '../threejs-3d-tiles/tile-parsers';
+import {transform2mapbox} from './web-mercator';
+
+export default class Mapbox3DTilesLayer {
+  constructor(params) {
+    if (!params) throw new Error('parameters missing for mapbox 3D tiles layer');
+    if (!params.id) throw new Error('id parameter missing for mapbox 3D tiles layer');
+    if (!params.url) throw new Error('url parameter missing for mapbox 3D tiles layer');
+
+    this.id = params.id;
+    this.url = params.url;
+
+    this.styleParams = {};
+    if ('color' in params) this.styleParams.color = params.color;
+    if ('opacity' in params) this.styleParams.opacity = params.opacity;
+    if ('pointsize' in params) this.styleParams.pointsize = params.pointsize;
+
+    this.loadStatus = 0;
+    this.viewProjectionMatrix = null;
+
+    this.type = 'custom';
+    this.renderingMode = '3d';
+  }
+
+  async onAdd(map, gl) {
+    this.map = map;
+    this.rootTransform = transform2mapbox([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]); // identity matrix tranformed to mapbox scale
+
+    this.renderer = new THREE.WebGLRenderer({
+      canvas: map.getCanvas(),
+      context: gl
+    });
+    this.renderer.autoClear = false;
+
+    this.camera = new THREE.Camera();
+    this.scene = new THREE.Scene();
+
+    const directionalLight = new THREE.DirectionalLight(0xffffff);
+    directionalLight.position.set(0, -70, 100).normalize();
+    this.scene.add(directionalLight);
+
+    const directionalLight2 = new THREE.DirectionalLight(0x999999);
+    directionalLight2.position.set(0, 70, 100).normalize();
+    this.scene.add(directionalLight2);
+
+    this.tileset = await loadTileset(this.url, this.styleParams);
+
+    if (this.tileset.root.transform) {
+      this.rootTransform = transform2mapbox(this.tileset.root.transform);
+    } else {
+      this.rootTransform = transform2mapbox([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]); // identity matrix tranformed to mapbox scale
+    }
+
+    if (this.tileset.root) {
+      this.scene.add(this.tileset.root.totalContent);
+    }
+
+    this.loadStatus = 1;
+
+    map.on('dragend', this.refresh.bind(this));
+    map.on('moveend', this.refresh.bind(this));
+  }
+
+  render(gl, viewProjectionMatrix) {
+    this.viewProjectionMatrix = viewProjectionMatrix;
+    const l = new THREE.Matrix4().fromArray(viewProjectionMatrix);
+    this.renderer.state.reset();
+
+    // The root tile transform is applied to the camera while rendering
+    // instead of to the root tile. This avoids precision errors.
+    this.camera.projectionMatrix = l.multiply(this.rootTransform);
+
+    this.renderer.render(this.scene, this.camera);
+
+    if (this.loadStatus === 1) {
+      // first render after root tile is loaded
+      this.loadStatus = 2;
+      const frustum = new THREE.Frustum();
+      frustum.setFromMatrix(
+        new THREE.Matrix4().multiplyMatrices(
+          this.camera.projectionMatrix,
+          this.camera.matrixWorldInverse
+        )
+      );
+
+      if (this.tileset.root) {
+        this.tileset.root.checkLoad(frustum, this._getCameraPosition());
+      }
+    }
+  }
+
+  // MAP CALLBACKS
+
+  refresh() {
+    const frustum = new THREE.Frustum();
+    frustum.setFromMatrix(
+      new THREE.Matrix4().multiplyMatrices(
+        this.camera.projectionMatrix,
+        this.camera.matrixWorldInverse
+      )
+    );
+    this.tileset.root.checkLoad(frustum, this._getCameraPosition());
+  }
+
+  // HELPERS
+
+  _getCameraPosition() {
+    if (!this.viewProjectionMatrix) {
+      return new THREE.Vector3();
+    }
+
+    const cam = new THREE.Camera();
+    const rootInverse = new THREE.Matrix4().getInverse(this.rootTransform);
+    cam.projectionMatrix.elements = this.viewProjectionMatrix;
+    cam.projectionMatrixInverse = new THREE.Matrix4().getInverse(cam.projectionMatrix); // add since three@0.103.0
+    const campos = new THREE.Vector3(0, 0, 0).unproject(cam).applyMatrix4(rootInverse);
+    return campos;
+  }
+}

--- a/examples/3d-tiles-threejs/mapbox-3d-tiles-layer/web-mercator.js
+++ b/examples/3d-tiles-threejs/mapbox-3d-tiles-layer/web-mercator.js
@@ -1,0 +1,24 @@
+import * as THREE from 'three';
+const WEBMERCATOR_EXTENT = 20037508.3427892;
+
+export function transform2mapbox(matrix) {
+  const min = -WEBMERCATOR_EXTENT;
+  const max = WEBMERCATOR_EXTENT;
+  const scale = 1 / (2 * WEBMERCATOR_EXTENT);
+
+  const result = matrix.slice(); // copy array
+  result[12] = (matrix[12] - min) * scale; // x translation
+  result[13] = (matrix[13] - max) * -scale; // y translation
+  result[14] = matrix[14] * scale; // z translation
+
+  return new THREE.Matrix4().fromArray(result).scale(new THREE.Vector3(scale, -scale, scale));
+}
+
+/*
+function webmercator2mapbox(x, y, z) {
+  const min = -WEBMERCATOR_EXTENT;
+  const max = WEBMERCATOR_EXTENT;
+  const range = 2 * WEBMERCATOR_EXTENT;
+  return [(x - min) / range, ((y - max) / range) * -1, z / range];
+}
+*/

--- a/examples/3d-tiles-threejs/package.json
+++ b/examples/3d-tiles-threejs/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "mapbox-3dtiles",
+  "description": "A loaders.gl port of Geodan's 3D Tiles layer for mapbox-gl/THREE.js",
+  "version": "0.5.0",
+  "author": "Geodan https://github.com/geodan/mapbox-3dtiles#readme",
+  "license": "BSD-3-Clause",
+  "main": "index.html",
+  "scripts": {
+    "start": "webpack-dev-server --progress --hot --open",
+    "start-local": "webpack-dev-server --env.local --progress --hot --open"
+  },
+  "dependencies": {
+    "@loaders.gl/core": "^1.3.0",
+    "@loaders.gl/3d-tiles": "^1.3.0",
+    "@loaders.gl/draco": "^1.3.0",
+    "mapbox-gl": "^1.1.1",
+    "three": "^0.106.2"
+  },
+  "devDependencies": {
+    "esm": ">=3.1.0",
+    "webpack": "^4.39.1",
+    "webpack-cli": "^3.1.2",
+    "webpack-dev-server": "^3.1.11"
+  }
+}
+

--- a/examples/3d-tiles-threejs/threejs-3d-tiles/tile-header.js
+++ b/examples/3d-tiles-threejs/threejs-3d-tiles/tile-header.js
@@ -72,7 +72,7 @@ export default class TileHeader {
 
     const dist = this.box.distanceToPoint(cameraPosition);
 
-    //console.log(`dist: ${dist}, geometricError: ${this.geometricError}`);
+    // console.log(`dist: ${dist}, geometricError: ${this.geometricError}`);
     // are we too far to render this tile?
     if (this.geometricError > 0.0 && dist > this.geometricError * 50.0) {
       this.unload(true);
@@ -80,7 +80,7 @@ export default class TileHeader {
     }
 
     // should we load this tile?
-    if (this.refine == 'REPLACE' && dist < this.geometricError * 20.0) {
+    if (this.refine === 'REPLACE' && dist < this.geometricError * 20.0) {
       this.unload(false);
     } else {
       this.load();
@@ -127,6 +127,7 @@ export default class TileHeader {
           const tileset = await loadTileset(url, this.styleParams);
           this.children.push(tileset.root);
           if (tileset.root) {
+            // eslint-disable-next-line max-depth
             if (tileset.root.transform) {
               // the root tile transform of a tileset is normally not applied because
               // it is applied by the camera while rendering. However, in case the tileset
@@ -157,7 +158,7 @@ export default class TileHeader {
           throw new Error('cmpt tiles not yet implemented');
 
         default:
-          throw new Error('invalid tile type: ' + type);
+          throw new Error(`invalid tile type: ${type}`);
       }
     }
   }
@@ -197,10 +198,7 @@ export default class TileHeader {
 
   _createGLTFNodes(d, tileContent) {
     const loader = new GLTFLoader();
-    const rotateX = new THREE.Matrix4().makeRotationAxis(
-      new THREE.Vector3(1, 0, 0),
-      Math.PI / 2
-    );
+    const rotateX = new THREE.Matrix4().makeRotationAxis(new THREE.Vector3(1, 0, 0), Math.PI / 2);
 
     tileContent.applyMatrix(rotateX); // convert from GLTF Y-up to Z-up
     loader.parse(
@@ -214,7 +212,7 @@ export default class TileHeader {
               if (this.styleParams.color !== null) child.material.color = color;
               if (this.styleParams.opacity !== null) {
                 child.material.opacity = this.styleParams.opacity;
-                child.material.transparent = this.styleParams.opacity < 1.0 ? true : false;
+                child.material.transparent = this.styleParams.opacity < 1.0;
               }
             }
           });
@@ -229,7 +227,7 @@ export default class TileHeader {
         tileContent.add(gltf.scene);
       },
       e => {
-        throw new Error('error parsing gltf: ' + e);
+        throw new Error(`error parsing gltf: ${e}`);
       }
     );
     return tileContent;

--- a/examples/3d-tiles-threejs/threejs-3d-tiles/tile-header.js
+++ b/examples/3d-tiles-threejs/threejs-3d-tiles/tile-header.js
@@ -1,0 +1,237 @@
+import * as THREE from 'three';
+import {GLTFLoader} from 'three/examples/jsm/loaders/GLTFLoader';
+
+import {loadTileset, loadBatchedModelTile, loadPointTile} from './tile-parsers';
+
+const DEBUG = false;
+
+export default class TileHeader {
+  // eslint-disable-next-line max-statements
+  constructor(json, resourcePath, styleParams, parentRefine, isRoot) {
+    this.loaded = false;
+    this.styleParams = styleParams;
+    this.resourcePath = resourcePath;
+
+    this._createTHREENodes();
+    this.totalContent.add(this.tileContent);
+    this.totalContent.add(this.childContent);
+    this.boundingVolume = json.boundingVolume;
+
+    if (this.boundingVolume && this.boundingVolume.box) {
+      const b = this.boundingVolume.box;
+      const extent = [b[0] - b[3], b[1] - b[7], b[0] + b[3], b[1] + b[7]];
+      const sw = new THREE.Vector3(extent[0], extent[1], b[2] - b[11]);
+      const ne = new THREE.Vector3(extent[2], extent[3], b[2] + b[11]);
+      this.box = new THREE.Box3(sw, ne);
+      if (DEBUG) {
+        const geom = new THREE.BoxGeometry(b[3] * 2, b[7] * 2, b[11] * 2);
+        const edges = new THREE.EdgesGeometry(geom);
+        const line = new THREE.LineSegments(edges, new THREE.LineBasicMaterial({color: 0x800000}));
+        const trans = new THREE.Matrix4().makeTranslation(b[0], b[1], b[2]);
+        line.applyMatrix(trans);
+        this.totalContent.add(line);
+      }
+    } else {
+      this.extent = null;
+      this.sw = null;
+      this.ne = null;
+      this.box = null;
+      this.center = null;
+    }
+    this.refine = json.refine ? json.refine.toUpperCase() : parentRefine;
+    this.geometricError = json.geometricError;
+    this.transform = json.transform;
+    if (this.transform && !isRoot) {
+      // if not the root tile: apply the transform to the THREE js Group
+      // the root tile transform is applied to the camera while rendering
+      this.totalContent.applyMatrix(new THREE.Matrix4().fromArray(this.transform));
+    }
+    this.content = json.content;
+    this.children = [];
+    if (json.children) {
+      for (let i = 0; i < json.children.length; i++) {
+        const child = new TileHeader(
+          json.children[i],
+          resourcePath,
+          styleParams,
+          this.refine,
+          false
+        );
+        this.childContent.add(child.totalContent);
+        this.children.push(child);
+      }
+    }
+  }
+
+  checkLoad(frustum, cameraPosition) {
+    // is this tile visible?
+    if (!frustum.intersectsBox(this.box)) {
+      this.unload(true);
+      return;
+    }
+
+    const dist = this.box.distanceToPoint(cameraPosition);
+
+    //console.log(`dist: ${dist}, geometricError: ${this.geometricError}`);
+    // are we too far to render this tile?
+    if (this.geometricError > 0.0 && dist > this.geometricError * 50.0) {
+      this.unload(true);
+      return;
+    }
+
+    // should we load this tile?
+    if (this.refine == 'REPLACE' && dist < this.geometricError * 20.0) {
+      this.unload(false);
+    } else {
+      this.load();
+    }
+
+    // should we load its children?
+    for (let i = 0; i < this.children.length; i++) {
+      if (dist < this.geometricError * 20.0) {
+        this.children[i].checkLoad(frustum, cameraPosition);
+      } else {
+        this.children[i].unload(true);
+      }
+    }
+  }
+
+  unload(includeChildren) {
+    this.tileContent.visible = false;
+    if (includeChildren) {
+      this.childContent.visible = false;
+    } else {
+      this.childContent.visible = true;
+    }
+    // TODO: should we also free up memory?
+  }
+
+  // eslint-disable-next-line max-statements, complexity
+  async load() {
+    this.tileContent.visible = true;
+    this.childContent.visible = true;
+    if (this.loaded) {
+      return;
+    }
+    this.loaded = true;
+
+    if (this.content) {
+      let url = this.content.uri ? this.content.uri : this.content.url;
+      if (!url) return;
+      if (url.substr(0, 4) !== 'http') url = this.resourcePath + url;
+      const type = url.slice(-4);
+
+      switch (type) {
+        case 'json':
+          // child is a tileset json
+          const tileset = await loadTileset(url, this.styleParams);
+          this.children.push(tileset.root);
+          if (tileset.root) {
+            if (tileset.root.transform) {
+              // the root tile transform of a tileset is normally not applied because
+              // it is applied by the camera while rendering. However, in case the tileset
+              // is a subset of another tileset, so the root tile transform must be applied
+              // to the THREE js group of the root tile.
+              tileset.root.totalContent.applyMatrix(
+                new THREE.Matrix4().fromArray(tileset.root.transform)
+              );
+            }
+            this.childContent.add(tileset.root.totalContent);
+          }
+          break;
+
+        case 'pnts':
+          const pointTile = await loadPointTile(url);
+          this._createPointNodes(pointTile, this.tileContent);
+          break;
+
+        case 'b3dm':
+          const d = await loadBatchedModelTile(url);
+          this._createGLTFNodes(d, this.tileContent);
+          break;
+
+        case 'i3dm':
+          throw new Error('i3dm tiles not yet implemented');
+
+        case 'cmpt':
+          throw new Error('cmpt tiles not yet implemented');
+
+        default:
+          throw new Error('invalid tile type: ' + type);
+      }
+    }
+  }
+
+  // THREE.js instantiation
+
+  _createTHREENodes() {
+    this.totalContent = new THREE.Group(); // Three JS Object3D Group for this tile and all its children
+    this.tileContent = new THREE.Group(); // Three JS Object3D Group for this tile's content
+    this.childContent = new THREE.Group(); // Three JS Object3D Group for this tile's children
+  }
+
+  _createPointNodes(d, tileContent) {
+    const geometry = new THREE.BufferGeometry();
+    geometry.addAttribute('position', new THREE.Float32BufferAttribute(d.points, 3));
+    const material = new THREE.PointsMaterial();
+    material.size = this.styleParams.pointsize !== null ? this.styleParams.pointsize : 1.0;
+    if (this.styleParams.color) {
+      material.vertexColors = THREE.NoColors;
+      material.color = new THREE.Color(this.styleParams.color);
+      material.opacity = this.styleParams.opacity !== null ? this.styleParams.opacity : 1.0;
+    } else if (d.rgba) {
+      geometry.addAttribute('color', new THREE.Float32BufferAttribute(d.rgba, 4));
+      material.vertexColors = THREE.VertexColors;
+    } else if (d.rgb) {
+      geometry.addAttribute('color', new THREE.Float32BufferAttribute(d.rgb, 3));
+      material.vertexColors = THREE.VertexColors;
+    }
+    tileContent.add(new THREE.Points(geometry, material));
+    if (d.rtc_center) {
+      const c = d.rtc_center;
+      tileContent.applyMatrix(new THREE.Matrix4().makeTranslation(c[0], c[1], c[2]));
+    }
+    tileContent.add(new THREE.Points(geometry, material));
+    return tileContent;
+  }
+
+  _createGLTFNodes(d, tileContent) {
+    const loader = new GLTFLoader();
+    const rotateX = new THREE.Matrix4().makeRotationAxis(
+      new THREE.Vector3(1, 0, 0),
+      Math.PI / 2
+    );
+
+    tileContent.applyMatrix(rotateX); // convert from GLTF Y-up to Z-up
+    loader.parse(
+      d.glbData,
+      this.resourcePath,
+      gltf => {
+        if (this.styleParams.color !== null || this.styleParams.opacity !== null) {
+          const color = new THREE.Color(this.styleParams.color);
+          gltf.scene.traverse(child => {
+            if (child instanceof THREE.Mesh) {
+              if (this.styleParams.color !== null) child.material.color = color;
+              if (this.styleParams.opacity !== null) {
+                child.material.opacity = this.styleParams.opacity;
+                child.material.transparent = this.styleParams.opacity < 1.0 ? true : false;
+              }
+            }
+          });
+        }
+        /*
+        const children = gltf.scene.children;
+        for (let i=0; i<children.length; i++) {
+          if (children[i].isObject3D)
+            tileContent.add(children[i]);
+        }
+        */
+        tileContent.add(gltf.scene);
+      },
+      e => {
+        throw new Error('error parsing gltf: ' + e);
+      }
+    );
+    return tileContent;
+  }
+}

--- a/examples/3d-tiles-threejs/threejs-3d-tiles/tile-parsers.js
+++ b/examples/3d-tiles-threejs/threejs-3d-tiles/tile-parsers.js
@@ -24,13 +24,13 @@ export async function loadTileset(url, styleParams) {
   return tileset;
 }
 
-
 export async function loadPointTile(url) {
   const content = await load(url, Tile3DLoader, {loadGLTF: false});
 
-  const tile = {};
-  tile.rtc_center = content.rtcCenter;
-  tile.points = content.attributes.positions;
+  const tile = {
+    rtc_center: content.rtcCenter, // eslint-disable-line camelcase
+    points: content.attributes.positions
+  };
   const {colors} = content.attributes;
   if (colors && colors.size === 3) {
     tile.rgb = colors.value;

--- a/examples/3d-tiles-threejs/threejs-3d-tiles/tile-parsers.js
+++ b/examples/3d-tiles-threejs/threejs-3d-tiles/tile-parsers.js
@@ -1,0 +1,75 @@
+/* global fetch */
+import * as THREE from 'three';
+import TileHeader from './tile-header';
+
+import {load} from '@loaders.gl/core';
+import {Tile3DLoader} from '@loaders.gl/3d-tiles';
+
+export async function loadTileset(url, styleParams) {
+  const response = await fetch(url);
+  const json = await response.json();
+
+  const tileset = {
+    url,
+    version: json.asset.version,
+    geometricError: json.geometricError,
+    gltfUpAxis: 'Z',
+    refine: json.refine ? json.refine.toUpperCase() : 'ADD',
+    root: null
+  };
+
+  const resourcePath = THREE.LoaderUtils.extractUrlBase(url);
+  tileset.root = new TileHeader(json.root, resourcePath, styleParams, tileset.refine, true);
+
+  return tileset;
+}
+
+
+export async function loadPointTile(url) {
+  const content = await load(url, Tile3DLoader, {loadGLTF: false});
+
+  const tile = {};
+  tile.rtc_center = content.rtcCenter;
+  tile.points = content.attributes.positions;
+  const {colors} = content.attributes;
+  if (colors && colors.size === 3) {
+    tile.rgb = colors.value;
+  }
+  if (colors && colors.size === 4) {
+    tile.rgba = colors.value;
+  }
+
+  return tile;
+}
+
+export async function loadBatchedModelTile(url) {
+  const content = await load(url, Tile3DLoader, {loadGLTF: false});
+  const tile = {};
+  tile.glbData = content.gltfArrayBuffer;
+  return tile;
+}
+
+/*
+export default class TileSetParser {
+  constructor() {
+    this.url = null;
+    this.version = null;
+    this.gltfUpAxis = 'Z';
+    this.geometricError = null;
+    this.root = null;
+  }
+
+  async load(url, styleParams) {
+    this.url = url;
+    const response = await fetch(url);
+    const json = await response.json();
+
+    this.version = json.asset.version;
+    this.geometricError = json.geometricError;
+    this.refine = json.refine ? json.refine.toUpperCase() : 'ADD';
+
+    const resourcePath = THREE.LoaderUtils.extractUrlBase(url);
+    this.root = new TileHeader(json.root, resourcePath, styleParams, this.refine, true);
+  }
+}
+*/

--- a/examples/3d-tiles-threejs/webpack.config.js
+++ b/examples/3d-tiles-threejs/webpack.config.js
@@ -1,0 +1,29 @@
+const CONFIG = {
+  mode: 'development',
+
+  entry: {
+    app: './app.js'
+  },
+
+  output: {
+    library: 'App'
+  },
+
+  module: {
+    rules: [
+      // {
+      //   // Transpile ES6 to ES5 with babel
+      //   // Remove if your app does not use JSX or you don't need to support old browsers
+      //   test: /\.js$/,
+      //   loader: 'babel-loader',
+      //   exclude: [/node_modules/],
+      //   options: {
+      //     presets: ['@babel/preset-env', '@babel/preset-react']
+      //   }
+      // }
+    ]
+  }
+};
+
+// This line enables bundling against src in this repo rather than installed module
+module.exports = env => (env ? require('../webpack.config.local')(CONFIG)(env) : CONFIG);


### PR DESCRIPTION
The current port uses loaders.gl to parse the tiles, but does not yet use loaders.gl traversal algorithm, see the pull request for more information.

Next step is to refactor the code to create THREE.js geometries in `onTileLoad` and `onTileUnload` callbacks. 

This is how loaders.gl `Tileset3D.traverse` works, so once that is done, replacing the current traversal with loaders.gl traversal should be relatively painless.