### PR TITLE
core: Use `context` to resolve loaders in sub-loaders

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ sudo: required
 dist: trusty
 addons:
 node_js:
-  - '8'
   - '10'
   - '12'
 install:

--- a/docs/developer-guide/creating-loaders-and-writers.md
+++ b/docs/developer-guide/creating-loaders-and-writers.md
@@ -33,3 +33,35 @@ Depending on how the underlying loader works (whether it is synchronous or async
 ## Dependency Management
 
 In general, it is recommended that loaders are "standalone" and avoid importing `@loaders.gl/core`. `@loaders.gl/loader-utils` provides a small set of shared loader utilities.
+
+## Creating Composite Loaders
+
+loaders.gl enables loaders to call other loaders (referred to as "sub-loaders" in this section). This enables loaders for "composite formats" to be "composed" out of loaders for the primitive parts.
+
+Good examples of sub-loaders are the `GLTFLoader` which can delegate Draco mesh decoding to the `DracoLoader` and image decoding to the various `ImageLoaders` and the `BasisLoader`.
+
+Naturally, Composite loaders can call other composite loaders, which is for instance used by the `Tile3DLoader` which uses the `GLTFLoader` to parse embedded glTF data in certain tiles.
+
+## Calling loaders inside loaders
+
+To call another loader, a loader should use the appropriate `parse` function provided in the `context` parameter.
+
+A conceptual example of a 3D Tiles loader calling the `GLTFLoader` with some additional options.
+
+```js
+export async function parse3DTile(arrayBuffer, options, context) {
+  const tile = {};
+  // Extract embedded GLB (if present) into `tile.gltfArrayBuffer`
+  ...
+  if (tile.gltfArrayBuffer) {
+    const {parse} = context;
+    tile.gltf = await parse(tile.gltfArrayBuffer, GLTFLoader, {
+      gltf: {...}
+    });
+  }
+}
+```
+
+Remarks:
+
+- While a loader could potentially import `parse` from `@loaders.gl/core` to invoke a sub-loader, it is discouraged, not only from a dependency management reasons, but it prevents loaders.gl from properly handling parameters and allow worker-loaders to call other loaders.

--- a/docs/developer-guide/using-loaders.md
+++ b/docs/developer-guide/using-loaders.md
@@ -59,16 +59,6 @@ selectLoader([ArrowLoader, CSVLoader], 'filename.csv'); // => CSVLoader
 
 Note: Selection works on urls and/or data
 
-## Using Worker Loaders
-
-Some loader modules provide _worker loaders_, e.g. the `DracoWorkerLoader`. These loaders execute on a worker thread, meaning that the main thread will not block during parsing. There can also be multiple parallel workers, potentially increasing parsing throughput on multicore CPUs.
-
-To use worker loaders, jut the worker loader
-
-Concurrency - The `maxConcurrency` parameter can be adjusted to define how many workers should be created for each format.
-
-Note that when calling worker loaders, binary data is transferred from the calling thread to the worker thread. This means that any `ArrayBuffer` `data` parameter you pass in to the worker will no longer be accessible in the calling thread.
-
 ## Loader Options
 
 `load`, `parse` and other core functions accept loader options in the form of an options object.
@@ -91,3 +81,49 @@ load(url, {
 An advantage of this design is that since the core functions can select a loader from a list of multiple candidate loaders, or invoke sub-loaders, the nested options system allows separate specification of options to each loader in a single options object.
 
 Loader options are merged with default options using a deep, two-level merge. Any object-valued key on the top level will be merged with the corresponding key value in the default options object.
+
+## Using Worker Loaders
+
+Some loader modules provide _worker loaders_, e.g. the `DracoWorkerLoader`. These loaders execute on a worker thread, meaning that the main thread will not block during parsing. There can also be multiple parallel workers, potentially increasing parsing throughput on multicore CPUs.
+
+To use worker loaders, jut the worker loader
+
+Concurrency - The `maxConcurrency` parameter can be adjusted to define how many workers should be created for each format.
+
+Note that when calling worker loaders, binary data is transferred from the calling thread to the worker thread. This means that any `ArrayBuffer` `data` parameter you pass in to the worker will no longer be accessible in the calling thread.
+
+## Using Composite Loaders
+
+loaders.gl enables the creation of _composite loaders_ that call other loaders (referred to as "sub-loaders" in this section). This enables loaders for "composite formats" to be quickly composed out of loaders for the primitive parts.
+
+Composite Loader usage is designed to be conceptually simple for applications (loaders.gl handles a number of subtleties under the hood).
+
+A composite loader is called just like any other loader, however there are some additional
+
+### Parameter Passing between Loaders
+
+Loaders and parameters are passed through to sub loaders and are merged so that applications can override them:
+
+```js
+  parse(data, [Tile3DLoader, GLTFLoader, DracoLoader], {
+    '3d-tiles': {
+      ...
+    },
+    gltf: {
+      ...
+    }
+  });
+```
+
+In this example:
+
+- the passed in loaders would override any loaders specified inside the sub-loaders as well as any globally registered loaders.
+- The options will be passed through to the sub-loaders, so that the `GLTFLoader` will receive the `gltf` options, merged with any `gltf` options set by the `Tile3DLoader`.
+
+This override system makes it easy for applications to test alternate sub-loaders or parameter options without having to modify any existing loader code.
+
+## Composite Loaders and Workers
+
+> Not currently implemented, but the plan is that loaders.gl will supports sub-loader invocation from worker loaders.
+
+A worker loader starts a seperate thread with a javascript bundle that only contains the code for that loader, so a worker loader needs to call the main thread (and indirectly, potentially another worker thread with another worrker loader) to parse using a sub-loader, properly transferring data into and back from the other thread.

--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -21,7 +21,7 @@
             {"entry": "docs/developer-guide/loader-categories"},
             {"entry": "docs/developer-guide/error-handling"},
             {"entry": "docs/developer-guide/polyfills"},
-            {"entry": "docs/developer-guide/create-new-loaders-and-writers"},
+            {"entry": "docs/developer-guide/creating-loaders-and-writers"},
             {"entry": "docs/roadmap"},
             {"entry": "docs/contributing"}
           ]

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -4,7 +4,7 @@
 
 Release Date: Target mid-Nov, 2019 (alpha/beta releases will soon become available)
 
-The 1.4 release focuses on introducing 2.0 concepts.
+The 1.4 release starts to introduce loaders.gl 2.0 concepts.
 
 ### @loaders.gl/core
 
@@ -12,6 +12,10 @@ The 1.4 release focuses on introducing 2.0 concepts.
 
   - All (non-worker) loaders are now required to expose a `parse` function (in addition to any more specialized `parseSync/parseText/parseInBatches` functions). This simplifies using loaders without `@loaders.gl/core`, which can reduce footprint in small applications.
   - All exported loader and writer objects now expose a `mimeType` field. This field is not yet used by `@loaders.gl/core` but is available for applications (e.g. see `selectLoader`).
+
+- **Composite Loaders**
+
+  - Loaders can call other loaders
 
 ## v1.3
 

--- a/modules/3d-tiles/src/lib/parsers/helpers/parse-3d-tile-gltf-view.js
+++ b/modules/3d-tiles/src/lib/parsers/helpers/parse-3d-tile-gltf-view.js
@@ -10,6 +10,7 @@
 // - Also, should we have hard dependency on gltf module or use injection or auto-discovery for gltf parser?
 
 import {GLTFLoader} from '@loaders.gl/gltf';
+import {getZeroOffsetArrayBuffer} from '@loaders.gl/loader-utils';
 
 export const GLTF_FORMAT = {
   URI: 0,
@@ -30,7 +31,7 @@ export function parse3DTileGLTFViewSync(tile, arrayBuffer, byteOffset) {
 
   // TODO - We can avoid copy if already 4-byte aligned...
   // However the rest of the code may not be able to accept byteOffsets, so copy anyway
-  tile.gltfArrayBuffer = copyArrayBuffer(arrayBuffer, byteOffset, gltfByteLength);
+  tile.gltfArrayBuffer = getZeroOffsetArrayBuffer(arrayBuffer, byteOffset, gltfByteLength);
   tile.gltfByteOffset = 0;
   tile.gltfByteLength = gltfByteLength;
 
@@ -59,7 +60,10 @@ export async function extractGLTF(tile, gltfFormat, options, context) {
     }
     if (tile.gltfArrayBuffer) {
       // TODO - Should handle byteOffset... However, not used now...
-      tile.gltf = await parse(tile.gltfArrayBuffer, GLTFLoader, {...options, parserVersion: 2});
+      tile.gltf = await parse(tile.gltfArrayBuffer, GLTFLoader, {
+        ...options,
+        gltf: {parserVersion: 2}
+      });
       delete tile.gltfArrayBuffer;
       delete tile.gltfByteOffset;
       delete tile.gltfByteLength;
@@ -74,7 +78,10 @@ export function extractGLTFSync(tile, gltfFormat, options, context) {
     if (tile.gltfArrayBuffer) {
       const {parseSync} = context;
       // TODO - Should handle byteOffset... Not used now...
-      tile.gltf = parseSync(tile.gltfArrayBuffer, GLTFLoader, {...options, parserVersion: 2});
+      tile.gltf = parseSync(tile.gltfArrayBuffer, GLTFLoader, {
+        ...options,
+        gltf: {parserVersion: 2}
+      });
       delete tile.gltfArrayBuffer;
       delete tile.gltfByteOffset;
       delete tile.gltfByteLength;
@@ -103,11 +110,4 @@ function extractGLTFBufferOrURL(tile, gltfFormat, options) {
     default:
       throw new Error(`b3dm: Illegal glTF format field`);
   }
-}
-
-// Copy the glb into new ArrayBuffer.
-function copyArrayBuffer(arrayBuffer, byteOffset, byteLength) {
-  const subArray = new Uint8Array(arrayBuffer).subarray(byteOffset, byteOffset + byteLength);
-  const arrayCopy = new Uint8Array(subArray);
-  return arrayCopy.buffer;
 }

--- a/modules/3d-tiles/test/lib/parsers/batched-model-3d-tile.spec.js
+++ b/modules/3d-tiles/test/lib/parsers/batched-model-3d-tile.spec.js
@@ -1,7 +1,6 @@
 // This file is derived from the Cesium code base under Apache 2 license
 // See LICENSE.md and https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md
 
-/* eslint-disable max-len */
 import test from 'tape-promise/tape';
 import {parse, encodeSync} from '@loaders.gl/core';
 import {Tile3DLoader, Tile3DWriter, TILE3D_TYPE} from '@loaders.gl/3d-tiles';

--- a/modules/3d-tiles/test/tile-3d-loader.spec.js
+++ b/modules/3d-tiles/test/tile-3d-loader.spec.js
@@ -1,24 +1,25 @@
 // This file is derived from the Cesium code base under Apache 2 license
 // See LICENSE.md and https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md
 
-/*
 import test from 'tape-promise/tape';
-import {parse, fetchFile, registerLoaders} from '@loaders.gl/core';
+import {parse, fetchFile} from '@loaders.gl/core';
 import {Tile3DLoader} from '@loaders.gl/3d-tiles';
 import {DracoLoader} from '@loaders.gl/draco';
 
-registerLoaders([DracoLoader]);
-
 const TILE_B3DM_WITH_DRACO_URL = '@loaders.gl/3d-tiles/test/data/143.b3dm';
 
-test('Tile3DLoader#Draco embedded offset corner case', async t => {
-  const response = await fetchFile(TILE_B3DM_WITH_DRACO_URL);
-  const tile = await parse(response, Tile3DLoader, {gltf: {parserVersion: 1}, DracoLoader, decompress: true});
+test('Tile3DLoader#Tile with GLB w/ Draco bufferviews', async t => {
+  let response = await fetchFile(TILE_B3DM_WITH_DRACO_URL);
+  let tile = await parse(response, [Tile3DLoader, DracoLoader], {gltf: {parserVersion: 2}});
   t.ok(tile);
 
-  const response2 = await fetchFile(TILE_B3DM_WITH_DRACO_URL);
-  const tile2 = await parse(response2, Tile3DLoader, {gltf: {parserVersion: 2}});
-  t.ok(tile2);
+  // DEPRECATED
+  response = await fetchFile(TILE_B3DM_WITH_DRACO_URL);
+  tile = await parse(response, [Tile3DLoader, DracoLoader], {
+    gltf: {parserVersion: 1, DracoLoader, decompress: true},
+    DracoLoader
+  });
+  t.ok(tile);
+
   t.end();
 });
-*/

--- a/modules/core/src/lib/loader-utils/get-loader-context.js
+++ b/modules/core/src/lib/loader-utils/get-loader-context.js
@@ -1,6 +1,16 @@
-export function getLoaderContext(context, options) {
+// "sub" loaders invoked by other loaders get a "context" injected on `this`
+// The context will inject core methods like `parse` and contain information
+// about loaders and options passed in to the top-level `parse` call.
+
+export function getLoaderContext(context, options, previousContext) {
+  // For recursive calls, we already have a context
+  // TODO - add any additional loaders to context?
+  if (previousContext) {
+    return previousContext;
+  }
   context = {
-    fetch: typeof window !== 'undefined' && window.fetch,
+    // TODO - determine how to inject fetch, fetch in options etc
+    fetch: context.fetch || (typeof window !== 'undefined' && window.fetch),
     ...context
   };
 

--- a/modules/core/src/lib/loader-utils/get-loader-context.js
+++ b/modules/core/src/lib/loader-utils/get-loader-context.js
@@ -30,3 +30,21 @@ export function getLoaderContext(context, options, previousContext) {
 
   return context;
 }
+
+export function getLoaders(loaders, context) {
+  // A single non-array loader disables lookup in context
+  if (!Array.isArray(loaders)) {
+    return loaders;
+  }
+
+  // Create a merged list
+  let candidateLoaders;
+  if (loaders) {
+    candidateLoaders = Array.isArray(loaders) ? loaders : [loaders];
+  }
+  if (context && context.loaders) {
+    const contextLoaders = Array.isArray(context.loaders) ? context.loaders : [context.loaders];
+    candidateLoaders = candidateLoaders ? [...candidateLoaders, ...contextLoaders] : contextLoaders;
+  }
+  return candidateLoaders;
+}

--- a/modules/core/src/lib/parse-sync.js
+++ b/modules/core/src/lib/parse-sync.js
@@ -15,7 +15,7 @@ export function parseSync(data, loaders, options, url) {
 
   options = options || {};
 
-    // We store the context in `this` using bind for "recursive" parse calls
+  // We store the context in `this` using bind for "recursive" parse calls
   // eslint-disable-next-line consistent-this, no-invalid-this
   let context = this;
 

--- a/modules/core/src/lib/parse-sync.js
+++ b/modules/core/src/lib/parse-sync.js
@@ -2,7 +2,7 @@ import {selectLoader} from './select-loader';
 import {isLoaderObject} from './loader-utils/normalize-loader';
 import {mergeOptions} from './loader-utils/merge-options';
 import {getArrayBufferOrStringFromDataSync} from './loader-utils/get-data';
-import {getLoaderContext} from './loader-utils/get-loader-context';
+import {getLoaders, getLoaderContext} from './loader-utils/get-loader-context';
 
 export function parseSync(data, loaders, options, url) {
   // Signature: parseSync(data, options, url)
@@ -13,8 +13,16 @@ export function parseSync(data, loaders, options, url) {
     loaders = null;
   }
 
-  // Chooses a loader and normalize it
-  const loader = selectLoader(loaders, url, data);
+  options = options || {};
+
+    // We store the context in `this` using bind for "recursive" parse calls
+  // eslint-disable-next-line consistent-this, no-invalid-this
+  let context = this;
+
+  // Chooses a loader (and normalizes it)
+  // Also use any loaders in the context, new loaders take priority
+  const candidateLoaders = getLoaders(loaders, context);
+  const loader = selectLoader(candidateLoaders, url, data);
   // Note: if nothrow option was set, it is possible that no loader was found, if so just return null
   if (!loader) {
     return null;
@@ -23,7 +31,7 @@ export function parseSync(data, loaders, options, url) {
   // Normalize options
   options = mergeOptions(loader, options);
 
-  const context = getLoaderContext({url, parseSync, loaders}, options);
+  context = getLoaderContext({url, parseSync, loaders}, options);
 
   return parseWithLoaderSync(loader, data, options, context);
 }

--- a/modules/core/src/lib/parse.js
+++ b/modules/core/src/lib/parse.js
@@ -3,22 +3,9 @@ import {isLoaderObject} from './loader-utils/normalize-loader';
 import {mergeOptions} from './loader-utils/merge-options';
 import {getUrlFromData} from './loader-utils/get-data';
 import {getArrayBufferOrStringFromData} from './loader-utils/get-data';
-import {getLoaderContext} from './loader-utils/get-loader-context';
+import {getLoaders, getLoaderContext} from './loader-utils/get-loader-context';
 import parseWithWorker from './loader-utils/parse-with-worker';
 import {selectLoader} from './select-loader';
-
-// TODO - move to loader-utils
-function getLoaders(loaders, context) {
-  let candidateLoaders;
-  if (loaders) {
-    candidateLoaders = Array.isArray(loaders) ? loaders : [loaders];
-  }
-  if (context && context.loaders) {
-    const contextLoaders = Array.isArray(context.loaders) ? context.loaders : [context.loaders];
-    candidateLoaders = candidateLoaders ? [...candidateLoaders, ...contextLoaders] : contextLoaders;
-  }
-  return candidateLoaders;
-}
 
 export async function parse(data, loaders, options, url) {
   // Signature: parse(data, options, url)
@@ -42,6 +29,10 @@ export async function parse(data, loaders, options, url) {
   // Also use any loaders in the context, new loaders take priority
   const candidateLoaders = getLoaders(loaders, context);
   const loader = selectLoader(candidateLoaders, autoUrl, data);
+  // Note: if nothrow option was set, it is possible that no loader was found, if so just return null
+  if (!loader) {
+    return null;
+  }
 
   // Normalize options
   options = mergeOptions(loader, options);

--- a/modules/csv/src/csv-loader.js
+++ b/modules/csv/src/csv-loader.js
@@ -47,17 +47,10 @@ function parseCSVInBatches(asyncIterator, options) {
   // Apps can call the parse method directly, we so apply default options here
   options = {...CSVLoader.options, ...options};
   options.csv = {...CSVLoader.options.csv, ...options.csv};
-<<<<<<< HEAD
 
   const {batchSize} = options.csv;
   const TableBatchType = options.csv.TableBatch;
 
-=======
-
-  const {batchSize} = options.csv;
-  const TableBatchType = options.TableBatch;
-
->>>>>>> csv optiions
   const asyncQueue = new AsyncQueue();
 
   let isFirstRow = true;

--- a/modules/csv/src/csv-loader.js
+++ b/modules/csv/src/csv-loader.js
@@ -47,10 +47,17 @@ function parseCSVInBatches(asyncIterator, options) {
   // Apps can call the parse method directly, we so apply default options here
   options = {...CSVLoader.options, ...options};
   options.csv = {...CSVLoader.options.csv, ...options.csv};
+<<<<<<< HEAD
 
   const {batchSize} = options.csv;
   const TableBatchType = options.csv.TableBatch;
 
+=======
+
+  const {batchSize} = options.csv;
+  const TableBatchType = options.TableBatch;
+
+>>>>>>> csv optiions
   const asyncQueue = new AsyncQueue();
 
   let isFirstRow = true;

--- a/modules/gltf/src/lib/extensions/KHR_lights_punctual.js
+++ b/modules/gltf/src/lib/extensions/KHR_lights_punctual.js
@@ -1,6 +1,6 @@
+import assert from '../utils/assert';
 import GLTFScenegraph from '../gltf-scenegraph';
 import {KHR_LIGHTS_PUNCTUAL} from '../gltf-constants';
-import assert from '../utils/assert';
 
 // GLTF EXTENSION: KHR_lights_punctual
 // https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_lights_punctual

--- a/modules/gltf/test/gltf-loader.spec.js
+++ b/modules/gltf/test/gltf-loader.spec.js
@@ -10,9 +10,9 @@ const GLTF_BINARY_URL = '@loaders.gl/gltf/test/data/gltf-2.0/2CylinderEngine.glb
 const GLTF_JSON_URL = '@loaders.gl/gltf/test/data/gltf-2.0/2CylinderEngine.gltf';
 
 // Extracted from Cesium 3D Tiles
-// const GLB_TILE_WITH_DRACO_URL = '@loaders.gl/gltf/test/data/3d-tiles/143.glb';
+const GLB_TILE_WITH_DRACO_URL = '@loaders.gl/gltf/test/data/3d-tiles/143.glb';
 const GLB_TILE_CESIUM_AIR_URL = '@loaders.gl/gltf/test/data/3d-tiles/Cesium_Air.glb';
-// const GLB_TILE_URL = '@loaders.gl/gltf/test/data/3d-tiles/tile.glb';
+const GLB_TILE_URL = '@loaders.gl/gltf/test/data/3d-tiles/tile.glb';
 
 registerLoaders([DracoLoader]);
 
@@ -68,12 +68,12 @@ test('GLTFLoader#Parses GLBs from 3D Tiles', async t => {
 });
 
 async function testTileGLBs(t, loaderOptions, version) {
-  // t.ok(await load(GLB_TILE_URL, GLTFLoader, loaderOptions), `Parser ${version}: Test GLB parses`);
+  t.ok(await load(GLB_TILE_URL, GLTFLoader, loaderOptions), `Parser ${version}: Test GLB parses`);
 
-  // t.ok(
-  //   await load(GLB_TILE_WITH_DRACO_URL, GLTFLoader, loaderOptions),
-  //   `Parser ${version}: Parses Draco GLB`
-  // );
+  t.ok(
+    await load(GLB_TILE_WITH_DRACO_URL, GLTFLoader, loaderOptions),
+    `Parser ${version}: Parses Draco GLB`
+  );
 
   t.rejects(
     async () => await load(GLB_TILE_CESIUM_AIR_URL, GLTFLoader, loaderOptions),

--- a/modules/zip/src/zip-loader.js
+++ b/modules/zip/src/zip-loader.js
@@ -5,6 +5,7 @@ export const ZipLoader = {
   extensions: ['zip'],
   mimeType: 'application/zip',
   category: 'archive',
+  test: 'PK',
   parse: parseZipAsync
 };
 
@@ -46,8 +47,7 @@ function parseZipAsync(data, options) {
       // Return fileMap
       .then(() => fileMap)
       .catch(error => {
-        options.log.error(`Unable to read zip archive: ${error}`);
-        throw error;
+        throw new Error(`Unable to read zip archive: ${error}`);
       })
   );
 }


### PR DESCRIPTION
When calling a loader from a loader, it is useful to be able to pass in and override loaders

```
parse(data, [Tile3DLoader, GLTFLoader, DracoLoader], 
```
And have the subloaders called by Tile3DLoader resolved against this list, overriding any locally specified or globally registered loaders.

```
Loader.parse(..., context) {
  const {parse} = context;
  parse(embeddedArrayBuffer);
}
```

This will significantly reduce the need for `registerLoaders` which should be a good thing.