### PR TITLE
3d-tiles: Remove sync parser versions

### DIFF
--- a/modules/3d-tiles/src/lib/parsers/parse-3d-tile-batched-model.js
+++ b/modules/3d-tiles/src/lib/parsers/parse-3d-tile-batched-model.js
@@ -15,12 +15,6 @@ export async function parseBatchedModel3DTile(tile, arrayBuffer, byteOffset, opt
   return byteOffset;
 }
 
-export function parseBatchedModel3DTileSync(tile, arrayBuffer, byteOffset, options, context) {
-  byteOffset = parseBatchedModel(tile, arrayBuffer, byteOffset, options, context);
-  extractGLTF(tile, GLTF_FORMAT.EMBEDDED, options, context);
-  return byteOffset;
-}
-
 export function parseBatchedModel(tile, arrayBuffer, byteOffset, options, context) {
   byteOffset = parse3DTileHeaderSync(tile, arrayBuffer, byteOffset, options);
 

--- a/modules/3d-tiles/src/lib/parsers/parse-3d-tile-composite.js
+++ b/modules/3d-tiles/src/lib/parsers/parse-3d-tile-composite.js
@@ -34,32 +34,3 @@ export async function parseComposite3DTile(
 
   return byteOffset;
 }
-
-// eslint-disable-next-line max-params
-export function parseComposite3DTileSync(
-  tile,
-  arrayBuffer,
-  byteOffset,
-  options,
-  context,
-  parse3DTileSync
-) {
-  byteOffset = parse3DTileHeaderSync(tile, arrayBuffer, byteOffset, options);
-
-  const view = new DataView(arrayBuffer);
-
-  // Extract number of tiles
-  tile.tilesLength = view.getUint32(byteOffset, true);
-  byteOffset += 4;
-
-  // extract each tile from the byte stream
-  tile.tiles = [];
-  while (tile.tiles.length < tile.tilesLength && tile.byteLength - byteOffset > 12) {
-    const subtile = {};
-    tile.tiles.push(subtile);
-    byteOffset = parse3DTileSync(arrayBuffer, byteOffset, options, context, subtile);
-    // TODO - do we need to add any padding in between tiles?
-  }
-
-  return byteOffset;
-}

--- a/modules/3d-tiles/src/lib/parsers/parse-3d-tile-instanced-model.js
+++ b/modules/3d-tiles/src/lib/parsers/parse-3d-tile-instanced-model.js
@@ -17,14 +17,6 @@ export async function parseInstancedModel3DTile(tile, arrayBuffer, byteOffset, o
   return byteOffset;
 }
 
-// Reference code:
-// https://github.com/AnalyticalGraphicsInc/cesium/blob/master/Source/Scene/Instanced3DModel3DTileContent.js#L190
-export function parseInstancedModel3DTileSync(tile, arrayBuffer, byteOffset, options, context) {
-  byteOffset = parseInstancedModel(tile, arrayBuffer, byteOffset, options, context);
-  // extractGLTFSync(tile, tile.gltfFormat, options, context);
-  return byteOffset;
-}
-
 function parseInstancedModel(tile, arrayBuffer, byteOffset, options, context) {
   byteOffset = parse3DTileHeaderSync(tile, arrayBuffer, byteOffset, options);
   if (tile.version !== 1) {

--- a/modules/3d-tiles/src/lib/parsers/parse-3d-tile-point-cloud.js
+++ b/modules/3d-tiles/src/lib/parsers/parse-3d-tile-point-cloud.js
@@ -29,25 +29,6 @@ export async function parsePointCloud3DTile(tile, arrayBuffer, byteOffset, optio
   return byteOffset;
 }
 
-// TODO - is there really a need for sync tile parsing?
-export function parsePointCloud3DTileSync(tile, arrayBuffer, byteOffset, options, context) {
-  byteOffset = parse3DTileHeaderSync(tile, arrayBuffer, byteOffset, options);
-  byteOffset = parse3DTileTablesHeaderSync(tile, arrayBuffer, byteOffset, options);
-  byteOffset = parse3DTileTablesSync(tile, arrayBuffer, byteOffset, options);
-
-  initializeTile(tile);
-
-  const {featureTable} = parsePointCloudTables(tile);
-
-  // parseDracoSync(tile, featureTable, batchTable, options);
-
-  parsePositions(tile, featureTable, options);
-  parseColors(tile, featureTable, options);
-  parseNormals(tile, featureTable, options);
-
-  return byteOffset;
-}
-
 function initializeTile(tile) {
   // Initialize point cloud tile defaults
   tile.attributes = {
@@ -247,6 +228,7 @@ export async function loadDraco(tile, dracoData, options, context) {
   };
 }
 
+// TODO - this is the remaining code from Cesium's parser
 /*
   const batchTable = new Tile3DBatchTable(tile);
 

--- a/modules/3d-tiles/src/lib/parsers/parse-3d-tile.js
+++ b/modules/3d-tiles/src/lib/parsers/parse-3d-tile.js
@@ -4,13 +4,10 @@
 import {TILE3D_TYPE} from '../constants';
 import {getMagicString} from './helpers/parse-utils';
 
-import {parsePointCloud3DTile, parsePointCloud3DTileSync} from './parse-3d-tile-point-cloud';
-import {parseBatchedModel3DTile, parseBatchedModel3DTileSync} from './parse-3d-tile-batched-model';
-import {
-  parseInstancedModel3DTile,
-  parseInstancedModel3DTileSync
-} from './parse-3d-tile-instanced-model';
-import {parseComposite3DTile, parseComposite3DTileSync} from './parse-3d-tile-composite';
+import {parsePointCloud3DTile} from './parse-3d-tile-point-cloud';
+import {parseBatchedModel3DTile} from './parse-3d-tile-batched-model';
+import {parseInstancedModel3DTile} from './parse-3d-tile-instanced-model';
+import {parseComposite3DTile} from './parse-3d-tile-composite';
 
 // Extracts
 export async function parse3DTile(arrayBuffer, byteOffset = 0, options, context, tile = {}) {
@@ -39,38 +36,6 @@ export async function parse3DTile(arrayBuffer, byteOffset = 0, options, context,
 
     case TILE3D_TYPE.POINT_CLOUD:
       return await parsePointCloud3DTile(tile, arrayBuffer, byteOffset, options, context);
-
-    default:
-      throw new Error(`3DTileLoader: unknown type ${tile.type}`); // eslint-disable-line
-  }
-}
-
-export function parse3DTileSync(arrayBuffer, byteOffset = 0, options, context, tile = {}) {
-  options = options['3d-tiles'] || {};
-
-  tile.byteOffset = byteOffset;
-  tile.type = getMagicString(arrayBuffer, byteOffset);
-
-  switch (tile.type) {
-    case TILE3D_TYPE.COMPOSITE:
-      // Note: We pass this function as argument so that embedded tiles can be parsed recursively
-      return parseComposite3DTileSync(
-        tile,
-        arrayBuffer,
-        byteOffset,
-        options,
-        context,
-        parse3DTileSync
-      );
-
-    case TILE3D_TYPE.BATCHED_3D_MODEL:
-      return parseBatchedModel3DTileSync(tile, arrayBuffer, byteOffset, options, context);
-
-    case TILE3D_TYPE.INSTANCED_3D_MODEL:
-      return parseInstancedModel3DTileSync(tile, arrayBuffer, byteOffset, options, context);
-
-    case TILE3D_TYPE.POINT_CLOUD:
-      return parsePointCloud3DTileSync(tile, arrayBuffer, byteOffset, options, context);
 
     default:
       throw new Error(`3DTileLoader: unknown type ${tile.type}`); // eslint-disable-line

--- a/modules/3d-tiles/src/tile-3d-loader.js
+++ b/modules/3d-tiles/src/tile-3d-loader.js
@@ -1,16 +1,9 @@
-import {parse3DTile, parse3DTileSync} from './lib/parsers/parse-3d-tile';
+import {parse3DTile} from './lib/parsers/parse-3d-tile';
 
 async function parse(arrayBuffer, options, context, loader) {
   const tile = {};
   const byteOffset = 0;
   await parse3DTile(arrayBuffer, byteOffset, options, context, tile);
-  return tile;
-}
-
-function parseSync(arrayBuffer, options, context, loader) {
-  const tile = {};
-  const byteOffset = 0;
-  parse3DTileSync(arrayBuffer, byteOffset, options, context, tile);
   return tile;
 }
 
@@ -21,7 +14,6 @@ export default {
   mimeType: 'application/octet-stream',
   test: ['cmpt', 'pnts', 'b3dm', 'i3dm'],
   parse,
-  parseSync,
   binary: true,
   defaultOptions: {
     '3d-tiles': {


### PR DESCRIPTION
For complex loaders that (depending on options) also need to do async processing, maintaining sync versions of the parsers doesn't make a lot of sense.

Removal cleans up and minimized code size. 

Technically a breaking change, but sync parsing functionality is already limited enough.