### PR TITLE
core: Merge nested options objects

### DIFF
--- a/dev-docs/RFCs/v2.0/loader-options-rfc.md
+++ b/dev-docs/RFCs/v2.0/loader-options-rfc.md
@@ -22,8 +22,8 @@ load(url, {
 ```
 
 ### Use-Case: Specifying Options to Individual Loaders without knowing which loader will be picked
-### Use-Case: Specifying Options to Sub Loaders
 
+### Use-Case: Specifying Options to Sub Loaders
 
 ## Proposals
 
@@ -44,7 +44,6 @@ It is convenient if the names are valid JS strings, so that they can used as obj
 All loaders for the same format (WorkerLoader, StreamingLoader) would be referenced by the same name.
 
 The user would need to decide the names for custom loaders.
-
 
 ## Problems
 

--- a/dev-docs/RFCs/v2.0/loader-options-rfc.md
+++ b/dev-docs/RFCs/v2.0/loader-options-rfc.md
@@ -1,0 +1,59 @@
+# RFC: loader option system
+
+- **Authors**: Ib Green
+- **Date**: Jun 2019
+- **Status**: Draft
+
+## Summary
+
+This RFC proposes a system for organizing loader options into subobjects, providing a structured way to pass options to multiple loaders, particularly in situations where it is not known in advance which loader will be selected, or when a loaders invokes other sub loaders.
+
+## Motivation
+
+When asking loaders.gl to load or parse a file using a list of loaders, and it is not clear in advance which loader will be picked, being able to do something like the following would look very pretty:
+
+```js
+load(url, {
+  json: {...},
+  csv: {...},
+  '3d-tiles': {...},
+  gltf: {...}
+});
+```
+
+### Use-Case: Specifying Options to Individual Loaders without knowing which loader will be picked
+### Use-Case: Specifying Options to Sub Loaders
+
+
+## Proposals
+
+### Deep Merge of Nested Loader Options (Implemented)
+
+Support nested options objects. Each loader type and category has a defined sub-field.
+
+Loader options are merged using a two-level merge. Any object-valued key on the top level will be merged with the corresponding key value in the other object.
+
+### Proposal: Loader subobject naming conventions
+
+It is convenient if the names are valid JS strings, so that they can used as object keys without quoting. Lower case, removing spaces, hyphens and underscores:
+
+- `draco`
+- `tileset3d`
+- `tile3d`
+
+All loaders for the same format (WorkerLoader, StreamingLoader) would be referenced by the same name.
+
+The user would need to decide the names for custom loaders.
+
+
+## Problems
+
+But how are these sub field names chosen? The loaders objects have different names, different capitalizations etc.
+
+A bunch of loaders will use the `json` extension (this particular issue is also discussed in a separate RFC).
+
+Since loaders can be pre-registered by other parts of the code, there may not be access to them when we want to use them.
+
+## The JSON problem
+
+The `json` subfield could cover a lot of formats. Should we define `json` to mean the JSON "streaming table" loader specifically, since we'll be doubling down on that loader as one of the primary loaders.gl loaders?

--- a/docs/developer-guide/using-loaders.md
+++ b/docs/developer-guide/using-loaders.md
@@ -71,11 +71,13 @@ Note that when calling worker loaders, binary data is transferred from the calli
 
 ## Loader Options
 
-Apis like `load`, `parse` etc accept an options object. Since these apis can select one of multiple loaders, or invoke sub-loaders, it is important to be able to specify options to multiple loaders.
+`load`, `parse` and other core functions accept loader options in the form of an options object.
 
-Therefor loader options objects are organized into sub objects, which provices a structured way to pass options to multiple loaders:
+```js
+parse(data, Loader, {...options});
+```
 
-Nested options object, where each loader type and category has a defined sub-field:
+Such loader options objects are organized into nested sub objects, with one sub-object per loader or loader category. This provides a structured way to pass options to multiple loaders.
 
 ```js
 load(url, {
@@ -85,5 +87,7 @@ load(url, {
   gltf: {...}
 });
 ```
+
+An advantage of this design is that since the core functions can select a loader from a list of multiple candidate loaders, or invoke sub-loaders, the nested options system allows separate specification of options to each loader in a single options object.
 
 Loader options are merged with default options using a deep, two-level merge. Any object-valued key on the top level will be merged with the corresponding key value in the default options object.

--- a/docs/developer-guide/using-loaders.md
+++ b/docs/developer-guide/using-loaders.md
@@ -68,3 +68,22 @@ To use worker loaders, jut the worker loader
 Concurrency - The `maxConcurrency` parameter can be adjusted to define how many workers should be created for each format.
 
 Note that when calling worker loaders, binary data is transferred from the calling thread to the worker thread. This means that any `ArrayBuffer` `data` parameter you pass in to the worker will no longer be accessible in the calling thread.
+
+## Loader Options
+
+Apis like `load`, `parse` etc accept an options object. Since these apis can select one of multiple loaders, or invoke sub-loaders, it is important to be able to specify options to multiple loaders.
+
+Therefor loader options objects are organized into sub objects, which provices a structured way to pass options to multiple loaders:
+
+Nested options object, where each loader type and category has a defined sub-field:
+
+```js
+load(url, {
+  json: {...},
+  csv: {...},
+  '3d-tiles': {...},
+  gltf: {...}
+});
+```
+
+Loader options are merged with default options using a deep, two-level merge. Any object-valued key on the top level will be merged with the corresponding key value in the default options object.

--- a/modules/core/src/lib/load.js
+++ b/modules/core/src/lib/load.js
@@ -1,7 +1,7 @@
 import {isFileReadable} from '../javascript-utils/is-type';
 import {fetchFile} from './fetch/fetch-file';
 import {isLoaderObject} from './loader-utils/normalize-loader';
-import {mergeLoaderAndUserOptions} from './loader-utils/normalize-options';
+import {mergeOptions} from './loader-utils/merge-options';
 import {selectLoader} from './select-loader';
 
 import {parse} from './parse';
@@ -34,7 +34,7 @@ export async function load(url, loaders, options) {
     // These can only be handled by `load`, not `parse`
     // TODO - ImageLoaders can be rewritten to separate load and parse, phase out this variant?
     if (loader.loadAndParse) {
-      const loaderOptions = mergeLoaderAndUserOptions(options, loader);
+      const loaderOptions = mergeOptions(loader, options);
       return await loader.loadAndParse(url, loaderOptions);
     }
   }

--- a/modules/core/src/lib/loader-utils/loggers.js
+++ b/modules/core/src/lib/loader-utils/loggers.js
@@ -1,3 +1,5 @@
+// probe.gl Log compatible loggers
+
 // Logs nothing
 export class NullLog {
   log() {
@@ -17,7 +19,7 @@ export class NullLog {
 // Logs to console
 export class ConsoleLog {
   constructor() {
-    this.console = console; // esli
+    this.console = console; // eslint-disable-line
   }
   log(...args) {
     return this.console.log.bind(this.console, ...args);

--- a/modules/core/src/lib/loader-utils/loggers.js
+++ b/modules/core/src/lib/loader-utils/loggers.js
@@ -1,0 +1,34 @@
+// Logs nothing
+export class NullLog {
+  log() {
+    return _ => {};
+  }
+  info() {
+    return _ => {};
+  }
+  warn() {
+    return _ => {};
+  }
+  error() {
+    return _ => {};
+  }
+}
+
+// Logs to console
+export class ConsoleLog {
+  constructor() {
+    this.console = console; // esli
+  }
+  log(...args) {
+    return this.console.log.bind(this.console, ...args);
+  }
+  info(...args) {
+    return this.console.info.bind(this.console, ...args);
+  }
+  warn(...args) {
+    return this.console.warn.bind(this.console, ...args);
+  }
+  error(...args) {
+    return this.console.error.bind(this.console, ...args);
+  }
+}

--- a/modules/core/src/lib/loader-utils/merge-options.js
+++ b/modules/core/src/lib/loader-utils/merge-options.js
@@ -1,0 +1,47 @@
+import {NullLog, ConsoleLog} from './loggers';
+
+const COMMON_DEFAULT_OPTIONS = {
+  log: new ConsoleLog()
+};
+
+const isPureObject = value =>
+  value && typeof value === 'object' && value.constructor === {}.constructor;
+// Merges
+export function mergeOptions(loader, options) {
+  const loaderDefaultOptions =
+    loader && (loader.DEFAULT_OPTIONS || loader.defaultOptions || loader.options || {});
+
+  const mergedOptions = {
+    ...COMMON_DEFAULT_OPTIONS,
+    ...loaderDefaultOptions,
+    dataType: 'arraybuffer', // TODO - explain why this option is needed for parsing
+    ...options // Merges any non-nested fields, but clobbers nested fields
+  };
+
+  // LOGGING
+
+  // options.log can be set to `null` to defeat logging
+  if (mergedOptions.log === null) {
+    mergedOptions.log = new NullLog();
+  }
+
+  // Merge nested fields
+  for (const key in options) {
+    const value = options[key];
+    // Check for nested options
+    // object in options => either no key in defaultOptions or object in defaultOptions
+    if (isPureObject(value) && key in loaderDefaultOptions) {
+      if (isPureObject(loaderDefaultOptions[key])) {
+        mergedOptions[key] = {
+          ...loaderDefaultOptions[key],
+          ...options[key]
+        };
+      } else {
+        mergedOptions.log.warn(`Nested option ${key} not recognized`)();
+      }
+    }
+    // else: No need to merge nested opts, and the initial merge already copied over the nested options
+  }
+
+  return mergedOptions;
+}

--- a/modules/core/src/lib/parse-in-batches-sync.js
+++ b/modules/core/src/lib/parse-in-batches-sync.js
@@ -1,5 +1,5 @@
 import {isLoaderObject} from './loader-utils/normalize-loader';
-import {mergeLoaderAndUserOptions} from './loader-utils/normalize-options';
+import {mergeOptions} from './loader-utils/merge-options';
 import {getIteratorFromData} from './loader-utils/get-data';
 import {getLoaderContext} from './loader-utils/get-loader-context';
 import {selectLoader} from './select-loader';
@@ -19,7 +19,7 @@ export async function parseInBatchesSync(data, loaders, options, url) {
   const loader = selectLoader(loaders, url, null);
 
   // Normalize options
-  options = mergeLoaderAndUserOptions(options, loader);
+  options = mergeOptions(loader, options);
 
   const context = getLoaderContext({url, loaders}, options);
 

--- a/modules/core/src/lib/parse-in-batches.js
+++ b/modules/core/src/lib/parse-in-batches.js
@@ -1,5 +1,5 @@
 import {isLoaderObject} from './loader-utils/normalize-loader';
-import {mergeLoaderAndUserOptions} from './loader-utils/normalize-options';
+import {mergeOptions} from './loader-utils/merge-options';
 import {getAsyncIteratorFromData} from './loader-utils/get-data';
 import {getLoaderContext} from './loader-utils/get-loader-context';
 import {selectLoader} from './select-loader';
@@ -18,7 +18,7 @@ export async function parseInBatches(data, loaders, options, url) {
   const loader = selectLoader(loaders, url, null);
 
   // Normalize options
-  options = mergeLoaderAndUserOptions(options, loader);
+  options = mergeOptions(loader, options);
 
   const context = getLoaderContext({url, loaders}, options);
 

--- a/modules/core/src/lib/parse-sync.js
+++ b/modules/core/src/lib/parse-sync.js
@@ -1,6 +1,6 @@
 import {selectLoader} from './select-loader';
 import {isLoaderObject} from './loader-utils/normalize-loader';
-import {mergeLoaderAndUserOptions} from './loader-utils/normalize-options';
+import {mergeOptions} from './loader-utils/merge-options';
 import {getArrayBufferOrStringFromDataSync} from './loader-utils/get-data';
 import {getLoaderContext} from './loader-utils/get-loader-context';
 
@@ -21,7 +21,7 @@ export function parseSync(data, loaders, options, url) {
   }
 
   // Normalize options
-  options = mergeLoaderAndUserOptions(options, loader);
+  options = mergeOptions(loader, options);
 
   const context = getLoaderContext({url, parseSync, loaders}, options);
 

--- a/modules/core/src/lib/parse.js
+++ b/modules/core/src/lib/parse.js
@@ -1,6 +1,6 @@
 import assert from '../utils/assert';
 import {isLoaderObject} from './loader-utils/normalize-loader';
-import {mergeLoaderAndUserOptions} from './loader-utils/normalize-options';
+import {mergeOptions} from './loader-utils/merge-options';
 import {getUrlFromData} from './loader-utils/get-data';
 import {getArrayBufferOrStringFromData} from './loader-utils/get-data';
 import {getLoaderContext} from './loader-utils/get-loader-context';
@@ -25,7 +25,7 @@ export async function parse(data, loaders, options, url) {
   const loader = selectLoader(loaders, autoUrl, data);
 
   // Normalize options
-  options = mergeLoaderAndUserOptions(options, loader);
+  options = mergeOptions(loader, options);
 
   const context = getLoaderContext({url: autoUrl, parse, loaders}, options);
 

--- a/modules/core/test/index.js
+++ b/modules/core/test/index.js
@@ -1,7 +1,5 @@
 import './javascript-utils';
 
-import './worker-utils';
-
 import './lib/fetch';
 import './lib/loader-utils';
 import './lib/progress/fetch-progress.spec';
@@ -10,5 +8,9 @@ import './lib/parse.spec';
 import './lib/load.spec';
 import './lib/register-loaders.spec';
 import './lib/select-loader.spec';
+
+// TODO - Worker utils tests test loading, not just worker farm
+// so we keep them after util tests
+import './worker-utils';
 
 import './deprecated/create-read-stream.spec';

--- a/modules/core/test/lib/loader-utils/index.js
+++ b/modules/core/test/lib/loader-utils/index.js
@@ -1,4 +1,6 @@
+import './loggers.spec';
+import './merge-options.spec';
+import './normalize-loader.spec';
 import './auto-parse.spec';
 import './check-error.spec';
 import './get-data.spec';
-import './normalize-loader.spec';

--- a/modules/core/test/lib/loader-utils/loggers.spec.js
+++ b/modules/core/test/lib/loader-utils/loggers.spec.js
@@ -1,0 +1,21 @@
+import test from 'tape-promise/tape';
+import {NullLog, ConsoleLog} from '@loaders.gl/core/lib/loader-utils/loggers';
+
+test('NullLog#methods', t => {
+  const log = new NullLog();
+  testLogger(t, log, 'NullLog');
+  t.end();
+});
+
+test('ConsoleLog#methods', t => {
+  const log = new ConsoleLog();
+  testLogger(t, log, 'ConsoleLog');
+  t.end();
+});
+
+function testLogger(t, log, logName) {
+  t.doesNotThrow(() => log.log()(), `${logName}.log()`);
+  t.doesNotThrow(() => log.info()(), `${logName}.info()`);
+  t.doesNotThrow(() => log.warn()(), `${logName}.warn()`);
+  t.doesNotThrow(() => log.error()(), `${logName}.error()`);
+}

--- a/modules/core/test/lib/loader-utils/merge-options.spec.js
+++ b/modules/core/test/lib/loader-utils/merge-options.spec.js
@@ -1,0 +1,11 @@
+/* eslint-disable max-len */
+import test from 'tape-promise/tape';
+import {mergeOptions} from '@loaders.gl/core/lib/loader-utils/merge-options';
+
+import {GLTFLoader} from '@loaders.gl/gltf';
+
+test('mergeOptions#mergeOptions', t => {
+  const options = mergeOptions(GLTFLoader, {gltf: {parserVersion: 2}});
+  t.ok(options.gltf.parserVersion, 2);
+  t.end();
+});


### PR DESCRIPTION
Plumbing towards supporting v2 options objects:

```js
load(url, {
  json: {...},
  csv: {...},
  '3d-tiles': {...},
  gltf: {...}
});
```

when working with multiple registered loaders or sub-loaders