### PR TITLE
gltf: drop parseSync, options refactor and doc refresh

### DIFF
--- a/dev-docs/RFCs/README.md
+++ b/dev-docs/RFCs/README.md
@@ -12,13 +12,15 @@ Writeups of directions in major areas of interest
 
 ## v2.0 RFCs
 
-| RFC                                              | Author   | Status    | Description                                   |
-| ------------------------------------------------ | -------- | --------- | --------------------------------------------- |
-| [\*\*\*\*](v2.0/json-loader-rfc.md)              | @ibgreen | **Draft** | Binary, streaming, worker-enabled JSON loader |
-| [\*\*\*\*](v2.0/json-support-rfc.md)             | @ibgreen | **Draft** | Core support for JSON formats                 |
-| [\*\*\*\*](v2.0/loader-auto-detection-rfc.md)    | @ibgreen | **Draft** | Improved support for loader auto detection    |
-| [\*\*\*\*](v2.0/loader-auto-registration-rfc.md) | @ibgreen | **Draft** | Loader auto registration at import            |
-| [\*\*\*\*](v2.0/loader-lookup-by-namerfc.md)     | @ibgreen | **Draft** | Loader lookup among pre-registered loaders    |
+| RFC                                                                  | Author   | Status    | Description                                   |
+| -------------------------------------------------------------------- | -------- | --------- | --------------------------------------------- |
+| [**Streaming JSON Loader**](v2.0/json-loader-rfc.md)                 | @ibgreen | **Draft** | Binary, streaming, worker-enabled JSON loader |
+| [**Loader Options**](v2.0/loader-option-rfc.md)                      | @ibgreen | **Draft** | Nested options scheme for loaders             |
+| [**Fetch Options**](v2.0/fetch-option-rfc.md)                        | @ibgreen | **Draft** | Options for `fetch`                           |
+| [**JSON**](v2.0/json-support-rfc.md)                                 | @ibgreen | **Draft** | Core support for JSON formats                 |
+| [**Loader Auto-Detection**](v2.0/loader-auto-detection-rfc.md)       | @ibgreen | **Draft** | Improved support for loader auto detection    |
+| [**Loader Auto-Registration**](v2.0/loader-auto-registration-rfc.md) | @ibgreen | **Draft** | Loader auto registration at import            |
+| [**Loader Lookup By Name**](v2.0/loader-lookup-by-namerfc.md)        | @ibgreen | **Draft** | Loader lookup among pre-registered loaders    |
 
 ## v1.0 RFCs
 

--- a/examples/deck.gl/3d-tiles/app.js
+++ b/examples/deck.gl/3d-tiles/app.js
@@ -16,12 +16,12 @@ import {registerLoaders} from '@loaders.gl/core';
 import {DracoWorkerLoader} from '@loaders.gl/draco';
 import {GLTFLoader} from '@loaders.gl/gltf';
 
-registerLoaders([GLTFLoader, DracoWorkerLoader]);
-
 import ControlPanel from './components/control-panel';
 import fileDrop from './components/file-drop';
 
 import {loadExampleIndex, INITIAL_EXAMPLE_CATEGORY, INITIAL_EXAMPLE_NAME} from './examples';
+
+registerLoaders([GLTFLoader, DracoWorkerLoader]);
 
 // Set your mapbox token here
 const MAPBOX_TOKEN = process.env.MapboxAccessToken; // eslint-disable-line

--- a/modules/3d-tiles/src/tile-3d-loader.js
+++ b/modules/3d-tiles/src/tile-3d-loader.js
@@ -15,7 +15,7 @@ export default {
   test: ['cmpt', 'pnts', 'b3dm', 'i3dm'],
   parse,
   binary: true,
-  defaultOptions: {
+  options: {
     '3d-tiles': {
       loadGLTF: true,
       decodeQuantizedPositions: false

--- a/modules/csv/src/csv-loader.js
+++ b/modules/csv/src/csv-loader.js
@@ -49,7 +49,7 @@ function parseCSVInBatches(asyncIterator, options) {
   options.csv = {...CSVLoader.options.csv, ...options.csv};
 
   const {batchSize} = options.csv;
-  const TableBatchType = options.TableBatch;
+  const TableBatchType = options.csv.TableBatch;
 
   const asyncQueue = new AsyncQueue();
 

--- a/modules/csv/src/csv-loader.js
+++ b/modules/csv/src/csv-loader.js
@@ -26,7 +26,7 @@ export default CSVLoader;
 function parseCSVSync(csvText, options) {
   // Apps can call the parse method directly, we so apply default options here
   options = {...CSVLoader.options, ...options};
-  options.gltf = {...CSVLoader.options.csv, ...options.gltf};
+  options.csv = {...CSVLoader.options.csv, ...options.csv};
 
   const config = {
     header: hasHeader(csvText, options),

--- a/modules/csv/src/csv-loader.js
+++ b/modules/csv/src/csv-loader.js
@@ -3,7 +3,7 @@ import {AsyncQueue, TableBatchBuilder, RowTableBatch} from '@loaders.gl/experime
 import Papa from './papaparse/papaparse.transpiled';
 import AsyncIteratorStreamer from './papaparse/async-iterator-streamer';
 
-export default {
+const CSVLoader = {
   name: 'CSV',
   extensions: ['csv'],
   mimeType: 'text/csv',
@@ -14,15 +14,24 @@ export default {
   parseInBatches: parseCSVInBatches,
   testText: null,
   options: {
-    TableBatch: RowTableBatch
+    csv: {
+      TableBatch: RowTableBatch,
+      batchSize: 10
+    }
   }
 };
 
+export default CSVLoader;
+
 function parseCSVSync(csvText, options) {
+  // Apps can call the parse method directly, we so apply default options here
+  options = {...CSVLoader.options, ...options};
+  options.gltf = {...CSVLoader.options.csv, ...options.gltf};
+
   const config = {
     header: hasHeader(csvText, options),
     dynamicTyping: true, // Convert numbers and boolean values in rows from strings
-    ...options,
+    ...options.csv,
     download: false, // We handle loading, no need for papaparse to do it for us
     error: e => {
       throw new Error(e);
@@ -35,10 +44,13 @@ function parseCSVSync(csvText, options) {
 
 // TODO - support batch size 0 = no batching/single batch?
 function parseCSVInBatches(asyncIterator, options) {
-  // options
-  const {batchSize = 10} = options;
+  // Apps can call the parse method directly, we so apply default options here
+  options = {...CSVLoader.options, ...options};
+  options.csv = {...CSVLoader.options.csv, ...options.csv};
 
+  const {batchSize} = options.csv;
   const TableBatchType = options.TableBatch;
+
   const asyncQueue = new AsyncQueue();
 
   let isFirstRow = true;

--- a/modules/csv/test/csv-loader-arrow.spec.js
+++ b/modules/csv/test/csv-loader-arrow.spec.js
@@ -11,8 +11,10 @@ const CSV_NUMBERS_10000_URL = '@loaders.gl/csv/test/data/numbers-10000.csv';
 
 test('CSVLoader#loadInBatches(numbers-100.csv, arrow)', async t => {
   const iterator = await loadInBatches(CSV_NUMBERS_100_URL, CSVLoader, {
-    TableBatch: ArrowTableBatch,
-    batchSize: 40
+    csv: {
+      TableBatch: ArrowTableBatch,
+      batchSize: 40
+    }
   });
 
   t.ok(isIterator(iterator) || isAsyncIterable(iterator), 'loadInBatches returned iterator');
@@ -30,8 +32,10 @@ test('CSVLoader#loadInBatches(numbers-100.csv, arrow)', async t => {
 
 test('CSVLoader#loadInBatches(numbers-10000.csv, arrow)', async t => {
   const iterator = await loadInBatches(CSV_NUMBERS_10000_URL, CSVLoader, {
-    TableBatch: ArrowTableBatch,
-    batchSize: 2000
+    csv: {
+      TableBatch: ArrowTableBatch,
+      batchSize: 2000
+    }
   });
   t.ok(isIterator(iterator) || isAsyncIterable(iterator), 'loadInBatches returned iterator');
 

--- a/modules/csv/test/csv-loader.spec.js
+++ b/modules/csv/test/csv-loader.spec.js
@@ -58,7 +58,9 @@ test('CSVLoader#load', async t => {
 
 test('CSVLoader#loadInBatches(sample.csv, columns)', async t => {
   const iterator = await loadInBatches(CSV_SAMPLE_URL, CSVLoader, {
-    TableBatch: ColumnarTableBatch
+    csv: {
+      TableBatch: ColumnarTableBatch
+    }
   });
   t.ok(isIterator(iterator) || isAsyncIterable(iterator), 'loadInBatches returned iterator');
 
@@ -80,8 +82,10 @@ test('CSVLoader#loadInBatches(sample.csv, columns)', async t => {
 test('CSVLoader#loadInBatches(sample-very-long.csv, columns)', async t => {
   const batchSize = 25;
   const iterator = await loadInBatches(CSV_SAMPLE_VERY_LONG_URL, CSVLoader, {
-    TableBatch: ColumnarTableBatch,
-    batchSize
+    csv: {
+      TableBatch: ColumnarTableBatch,
+      batchSize
+    }
   });
   t.ok(isIterator(iterator) || isAsyncIterable(iterator), 'loadInBatches returned iterator');
 
@@ -128,7 +132,7 @@ test('CSVLoader#loadInBatches(sample.csv, rows)', async t => {
 
 test('CSVLoader#loadInBatches(sample-very-long.csv, rows)', async t => {
   const batchSize = 25;
-  const iterator = await loadInBatches(CSV_SAMPLE_VERY_LONG_URL, CSVLoader, {batchSize});
+  const iterator = await loadInBatches(CSV_SAMPLE_VERY_LONG_URL, CSVLoader, {csv: {batchSize}});
   t.ok(isIterator(iterator) || isAsyncIterable(iterator), 'loadInBatches returned iterator');
 
   let batchCount = 0;

--- a/modules/draco/src/draco-loader.js
+++ b/modules/draco/src/draco-loader.js
@@ -16,5 +16,6 @@ export default {
   binary: true,
   test: 'DRACO',
   parse: async (arrayBuffer, options) => parseSync(arrayBuffer, options),
-  parseSync
+  parseSync,
+  options: {}
 };

--- a/modules/gltf/docs/api-reference/glb-loader.md
+++ b/modules/gltf/docs/api-reference/glb-loader.md
@@ -4,15 +4,13 @@ The `GLBLoader` parses a GLB binary "envelope".
 
 Note: applications that want to parse GLB-formatted glTF files use the `GLTFLoader` instead. The `GLBLoader` is intended to be used to load custom data that combines JSON and binary resources.
 
-| Loader                | Characteristic                                                                                          |
-| --------------------- | ------------------------------------------------------------------------------------------------------- |
-| File Extensions       | `.glb`                                                                                                  |
-| File Type             | Binary                                                                                                  |
-| File Format           | [GLB](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#glb-file-format-specification) |
-| Data Format           | See below                                                                                               |
-| Decoder Type          | Synchronous                                                                                             |
-| Worker Thread Support | No                                                                                                      |
-| Streaming Support     | No                                                                                                      |
+| Loader          | Characteristic                                                                                          |
+| --------------- | ------------------------------------------------------------------------------------------------------- |
+| File Extensions | `.glb`                                                                                                  |
+| File Type       | Binary                                                                                                  |
+| File Format     | [GLB](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#glb-file-format-specification) |
+| Data Format     | See below                                                                                               |
+| Supported APIs  | `parse`, `parseSync`                                                                                    |
 
 ## Usage
 
@@ -24,9 +22,9 @@ const gltf = await load(url, GLBLoader);
 
 ## Options
 
-| Option  | Type   | Default | Description                              |
-| ------- | ------ | ------- | ---------------------------------------- |
-| `magic` | Number | glTF    | The magic number to be save in the file. |
+| Option                    | Type    | Default | Description                                                  |
+| ------------------------- | ------- | ------- | ------------------------------------------------------------ |
+| `glb.strict` (DEPRECATED) | Boolean | `false` | Whether to support non-standard JSON/BIN chunk type numbers. |
 
 ## Data Format
 

--- a/modules/gltf/docs/api-reference/glb-writer.md
+++ b/modules/gltf/docs/api-reference/glb-writer.md
@@ -4,15 +4,13 @@ The `GLBWriter` is a writer for the GLB binary "envelope".
 
 Note: applications that want to encode GLB-formatted glTF files use the `GLTFWriter` instead. The `GLBWriter` is intended to be used to save custom data that combines JSON and binary resources.
 
-| Loader                | Characteristic                                                                                          |
-| --------------------- | ------------------------------------------------------------------------------------------------------- |
-| File Extensions       | `.glb`                                                                                                  |
-| File Type             | Binary                                                                                                  |
-| Data Format           | See below                                                                                               |
-| File Format           | [GLB](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#glb-file-format-specification) |
-| Encoder Type          | Synchronous                                                                                             |
-| Worker Thread Support | No                                                                                                      |
-| Streaming Support     | No                                                                                                      |
+| Loader          | Characteristic                                                                                          |
+| --------------- | ------------------------------------------------------------------------------------------------------- |
+| File Extensions | `.glb`                                                                                                  |
+| File Type       | Binary                                                                                                  |
+| Data Format     | See below                                                                                               |
+| File Format     | [GLB](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#glb-file-format-specification) |
+| Supported APIs  | `encode`, `encodeSync`                                                                                  |
 
 ## Usage
 
@@ -25,17 +23,10 @@ const arrayBuffer = encodeSync(gltf, GLBWriter, options);
 
 ## Options
 
-| Option  | Type   | Default | Description                              |
-| ------- | ------ | ------- | ---------------------------------------- |
-| `magic` | Number | glTF    | The magic number to be save in the file. |
+| Option | Type | Default | Description |
+| ------ | ---- | ------- | ----------- |
+| N/A    | N/A  | N/A     | N/A         |
 
 ## Data Format
 
-See `GLBLoader`.
-
-| Field     | Type          | Default | Description                      |
-| --------- | ------------- | ------- | -------------------------------- |
-| `magic`   | `Number`      | glTF    | The first four bytes of the file |
-| `version` | `Number`      | `2`     | The version number               |
-| `json`    | `Object`      | `{}`    | The JSON chunk                   |
-| `binary`  | `ArrayBuffer` | `null`  | The binary chunk                 |
+See [`GLBLoader`](/modules/gltf/docs/api-reference/glb-loader.md).

--- a/modules/gltf/docs/api-reference/gltf-extensions.md
+++ b/modules/gltf/docs/api-reference/gltf-extensions.md
@@ -1,8 +1,10 @@
 # glTF Extensions
 
-Arbitrary glTF extensions can be present in glTF files, and will remain present in the parsed JSON as you would expect. Such extensions can supported by applications by inspecting the `extensions` fields inside glTF objects, and it is up to each application to handle or ignore them.
+glTF extensions can be present in glTF files, and will be present in the parsed JSON. glTF extensions can supported by applications by inspecting the `extensions` fields inside glTF objects, and it is up to each application to handle or ignore them.
 
-Many glTF extensions affect e.g. rendering which is outside of the scope of loaders.gl, however in a few cases it is possible to provide support for extensions directly during loading. This article describes glTF extensions that are fully or partially processed by the `@loaders.gl/gltf` classes.
+loaders.gl aims to provide support for glTF extensions that can be handled completely or partially during loading, and article describes glTF extensions that are fully or partially processed by the `@loaders.gl/gltf` classes.
+
+Note that many glTF extensions affect aspects that are firmly outside of the scope of loaders.gl (e.g. rendering), and no attempt is made to process those extensions in loaders.gl.
 
 ## Official Extensions
 

--- a/modules/gltf/docs/api-reference/gltf-loader.md
+++ b/modules/gltf/docs/api-reference/gltf-loader.md
@@ -4,30 +4,13 @@ Parses a glTF file. Can load both the `.glb` (binary) and `.gltf` (text/json) fi
 
 A glTF file contains a hierarchical scenegraph description that can be used to instantiate corresponding hierarcy of actual `Scenegraph` related classes in most WebGL libraries.
 
-| Loader                | Characteristic                                                             |
-| --------------------- | -------------------------------------------------------------------------- |
-| File Extensions       | `.glb`, `.gltf`                                                            |
-| File Type             | Binary, JSON, Linked Assets                                                |
-| File Format           | [glTF](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0) |
-| Data Format           | [Scenegraph](/docs/specifications/category-scenegraph)                     |
-| Decoder Type          | Synchronous (limited), Asynchronous                                        |
-| Worker Thread Support | No                                                                         |
-| Streaming Support     | No                                                                         |
-
-The `GLTFLoader` aims to take care of as much processing as possible, while remaining framework-independent.
-
-The GLTF Loader returns an object with a `json` field containing the glTF Scenegraph. In its basic mode, the `GLTFLoader` does not modify the loaded JSON in any way. Instead, the results of additional processing are placed in parallel top-level fields such as `buffers` and `images`. This ensures that applications that want to work with the standard glTF data structure can do so.
-
-Optionally, the loaded gltf can be "post processed", which lightly annotates and transforms the loaded JSON structure to make it easier to use. Refer to [postProcessGLTF](docs/api-reference/gltf-loaders/gltf-extensions.md) for details.
-
-In addition, certain glTF extensions, in particular Draco mesh encoding, can be fully or partially processed during loading. When possible (and extension processing is enabled), such extensions will be resolved/decompressed and replaced with standards conformant representations. See [glTF Extensions](docs/api-reference/gltf-loaders/gltf-extensions.md) for more information.
-
-Note: while supported, synchronous parsing of glTF (e.g. using `parseSync()`) has significant limitations. When parsed asynchronously (using `await parse()` or `await load()`), the following additional capabilities are enabled:
-
-- linked binary resource URI:s will be loaded and resolved (assuming a valid base url is available).
-- base64 encoded binary URI:s inside the JSON payload will be decoded.
-- linked image URI:s can be loaded and decoded.
-- Draco meshes can be decoded asynchronously on worker threads (in parallel!).
+| Loader          | Characteristic                                                             |
+| --------------- | -------------------------------------------------------------------------- |
+| File Extensions | `.glb`, `.gltf`                                                            |
+| File Type       | Binary, JSON, Linked Assets                                                |
+| File Format     | [glTF](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0) |
+| Data Format     | [Scenegraph](/docs/specifications/category-scenegraph)                     |
+| Supported APIs  | `parse`, `parseSync`                                                       |
 
 ## Usage
 
@@ -46,22 +29,77 @@ import {DracoLoader} from '@loaders.gl/draco';
 const gltf = load(url, GLTFLoader, {DracoLoader, decompress: true});
 ```
 
+## Overview
+
+The `GLTFLoader` aims to take care of as much processing as possible, while remaining framework-independent.
+
+The GLTF Loader returns an object with a `json` field containing the glTF Scenegraph. In its basic mode, the `GLTFLoader` does not modify the loaded JSON in any way. Instead, the results of additional processing are placed in parallel top-level fields such as `buffers` and `images`. This ensures that applications that want to work with the standard glTF data structure can do so.
+
+Optionally, the loaded gltf can be "post processed", which lightly annotates and transforms the loaded JSON structure to make it easier to use. Refer to [postProcessGLTF](docs/api-reference/gltf-loaders/gltf-extensions.md) for details.
+
+In addition, certain glTF extensions, in particular Draco mesh encoding, can be fully or partially processed during loading. When possible (and extension processing is enabled), such extensions will be resolved/decompressed and replaced with standards conformant representations. See [glTF Extensions](docs/api-reference/gltf-loaders/gltf-extensions.md) for more information.
+
+Note: while supported, synchronous parsing of glTF (e.g. using `parseSync()`) has significant limitations. When parsed asynchronously (using `await parse()` or `await load()`), the following additional capabilities are enabled:
+
+- linked binary resource URI:s will be loaded and resolved (assuming a valid base url is available).
+- base64 encoded binary URI:s inside the JSON payload will be decoded.
+- linked image URI:s can be loaded and decoded.
+- Draco meshes can be decoded asynchronously on worker threads (in parallel!).
+
 ## Options
 
-| Option                 | Type                                                  | Default Async | Sync                                                                                                           | Description                                                                                 |
-| ---------------------- | ----------------------------------------------------- | ------------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| `fetchLinkedResources` | Boolean                                               | `true`        | No                                                                                                             | Fetch any linked .BIN files, decode base64 encoded URIS. Async only.                        |
-| `fetchImages`          | Boolean                                               | `false`       | No                                                                                                             | Fetch any referenced image files (and decode base64 encoded URIS). Async only.              |
-| `createImages`         | Boolean                                               | `false`       | Create image objects from loaded image data.                                                                   |
-| `fetch`                | Function                                              | `fetch`       | N/A                                                                                                            | Function used to fetch linked resources.                                                    |
-| `uri`                  | String                                                | `fetch`       | N/A                                                                                                            | Function used to fetch linked resources.                                                    |
-| `decompress`           | Boolean                                               | `true`        | Yes                                                                                                            | Decompress Draco compressed meshes (if DracoLoader available).                              |
-| `DracoLoader`          | [DracoLoader](/docs/api-reference/draco/draco-loader) | `null`        | Yes\*                                                                                                          | Supply to enable decoding of Draco compressed meshes. \* `DracoWorkerLoader` is async only. |
-| `postProcess`          | Boolean                                               | `false`       | Perform additional [post processing](docs/api-reference/post-process-gltf) to simplify use in WebGL libraries. |
+The following options are used when `gltf.parserVersion` is set to `2`:
+
+| Option               | Type    | Default |                                                                                | Description |
+| -------------------- | ------- | ------- | ------------------------------------------------------------------------------ | ----------- |
+| `gltf.parserVersion` | Number  | `1`     | F                                                                              |
+| `gltf.fetchImages`   | Boolean | `false` | Fetch any referenced image files (and decode base64 encoded URIS). Async only. |
+| `gltf.parseImages`   | Boolean | `false` |
+| `gltf.decompress`    | Boolean | `true`  | Decompress Draco compressed meshes (if DracoLoader available).                 |
+| `gltf.postProcess`   | Boolean | `true`  | Perform additional post processing before returning data.                      |
+
+DEPRECATED OPTIONS
+
+The foillowing top-level options are deprecated and will be removed in v2.0
+
+| Option                 | Type          | Default | Description                                                                    |
+| ---------------------- | ------------- | ------- | ------------------------------------------------------------------------------ |
+| `fetchLinkedResources` | Boolean       | `true`  | Fetch any linked .BIN files, decode base64 encoded URIS. Async only.           |
+| `fetchImages`          | Boolean       | `false` | Fetch any referenced image files (and decode base64 encoded URIS). Async only. |
+| `createImages`         | Boolean       | `false` |                                                                                |
+| `fetch`                | Function      | `fetch` | Function used to fetch linked resources.                                       |
+| `uri`                  | String        | `fetch` | Function used to fetch linked resources.                                       |
+| `decompress`           | Boolean       | `true`  | Decompress Draco compressed meshes (if DracoLoader available).                 |
+| `DracoLoader`          | `DracoLoader` | `null`  | Supply to enable decoding of Draco compressed meshes.                          |
+| `postProcess`          | Boolean       | `false` | Perform additional post processing before returning data.                      |
+
+Remarks:
+
+- The v1 parser will be removed in loaders.gl v2.0
+- `postProcess`: Performs additional [post processing](docs/api-reference/post-process-gltf) to simplify use in WebGL libraries. Changes the return value of the call.
 
 ## Data Format
 
-Returns
+### With Post Processing
+
+The format of data returned by the `GLTFLoader` depends on whether the `gltf.postProcess` option is `true`. When true, the parsed JSON structure will be returned, and [post processing](docs/api-reference/post-process-gltf) will have been performed, which will link data from binary buffers into the parsed JSON structure using non-standard fields, and also modify the data in other ways to make it easier to use.
+
+At the top level, this will look like a standard json structure:
+
+```json
+{
+  scenes: [...],
+  scene: ...,
+  nodes: [...],
+  ...
+}
+```
+
+For details on the extra fields added to the returned data structure, see [post processing](docs/api-reference/post-process-gltf).
+
+### With Post Processing
+
+By setting `gltf.postProcess` to `false`, a "pure" gltf data structure will be returned, with binary buffers provided as an `ArrayBuffer` array.
 
 ```json
 {
@@ -69,7 +107,7 @@ Returns
   baseUri: String,
 
   // JSON Chunk
-  json: Object,
+  json: Object, // This will be the standard glTF json structuure shown above
 
   // Length and indices of this array will match `json.buffers`
   // The GLB bin chunk, if present, will be found in buffer 0.

--- a/modules/gltf/docs/api-reference/gltf-scenegraph.md
+++ b/modules/gltf/docs/api-reference/gltf-scenegraph.md
@@ -2,7 +2,7 @@
 
 The `GLTFScenegraph` class provides an API for accessing and modifying glTF data.
 
-> Caveat: Modification of existing binary data chunks has limitations, this class is not intended to be a generic utility for modifying existing glTF data.
+> Caveat: Modification of binary data chunks has limitations, and this class is currently not intended to be a generic utility for modifying glTF data.
 
 ## Usage
 

--- a/modules/gltf/docs/api-reference/gltf-writer.md
+++ b/modules/gltf/docs/api-reference/gltf-writer.md
@@ -2,15 +2,13 @@
 
 The `GLTFWriter` is a writer for glTF scenegraphs.
 
-| Loader                | Characteristic                                                             |
-| --------------------- | -------------------------------------------------------------------------- |
-| File Extensions       | `.glb`,`.gltf`                                                             |
-| File Types            | Binary, JSON, Linked Assets                                                |
-| Data Format           | [Scenegraph](/docs/specifications/category-scenegraph)                     |
-| File Format           | [glTF](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0) |
-| Encoder Type          | Synchronous (limited), Asynchronous                                        |
-| Worker Thread Support | No                                                                         |
-| Streaming Support     | No                                                                         |
+| Loader          | Characteristic                                                             |
+| --------------- | -------------------------------------------------------------------------- |
+| File Extensions | `.glb`,`.gltf`                                                             |
+| File Types      | Binary, JSON, Linked Assets                                                |
+| Data Format     | [Scenegraph](/docs/specifications/category-scenegraph)                     |
+| File Format     | [glTF](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0) |
+| Supported APIs  | `encode`, `encodeSync`                                                     |
 
 ## Usage
 

--- a/modules/gltf/docs/api-reference/post-process-gltf.md
+++ b/modules/gltf/docs/api-reference/post-process-gltf.md
@@ -7,15 +7,25 @@ The `postProcessGLTF` function transforms parsed GLTF JSON to make it easier to 
 
 ## Usage
 
-To post process just pass a gltf object to the `GLTFPostProcessor`
+Postprocessing is done by default in the v2 `GLTFLoader`:
 
 ```js
-import {GLTFLoader, postProcessGLTF} from '@loaders.gl/gltf';
-const gltf = await parse(..., GLTFLoader);
+import {GLTFLoader} from '@loaders.gl/gltf';
+const gltf = await parse(..., GLTFLoader, {
+  {gltf: {parserVersion: 2}}
+});
 const processedGLTF = postProcesssGLTF(gltf);
 ```
 
-After post-processing, the gltf scenegraphs are now easier to iterate over
+To turn post processing off, and then optionally post process via `postProcessGLTF` function:
+
+```js
+import {GLTFLoader, postProcessGLTF} from '@loaders.gl/gltf';
+const gltf = await parse(..., GLTFLoader, {gltf: {parserVersion: 2, postProcess: false}});
+const processedGLTF = postProcesssGLTF(gltf);
+```
+
+After post-processing, the gltf scenegraphs are now easier to iterate over as indices have been resolved to object references:
 
 ```js
 const scenegraph = processedGLTF.scenegraphs[0];

--- a/modules/gltf/src/glb-loader.js
+++ b/modules/gltf/src/glb-loader.js
@@ -9,8 +9,10 @@ export default {
   binary: true,
   parse: async (arrayBuffer, options) => parseSync(arrayBuffer, options),
   parseSync,
-  defaultOptions: {
-    strict: false // Enables deprecated XVIZ support (illegal CHUNK formats)
+  options: {
+    glb: {
+      strict: false // Enables deprecated XVIZ support (illegal CHUNK formats)
+    }
   }
 };
 

--- a/modules/gltf/src/glb-writer.js
+++ b/modules/gltf/src/glb-writer.js
@@ -5,7 +5,10 @@ export default {
   extensions: ['glb'],
   mimeType: 'model/gltf-binary',
   encodeSync,
-  binary: true
+  binary: true,
+  options: {
+    glb: {}
+  }
 };
 
 function encodeSync(glb, options) {

--- a/modules/gltf/src/index.js
+++ b/modules/gltf/src/index.js
@@ -14,7 +14,6 @@ export {default as GLTFScenegraph} from './lib/gltf-scenegraph';
 export {default as postProcessGLTF} from './lib/post-process-gltf';
 
 // For 3D Tiles
-export {parseGLTFSync} from './lib/parse-gltf';
 export {encodeGLTFSync} from './lib/encode-gltf';
 
 // DEPRECATED

--- a/modules/gltf/src/lib/extensions/KHR_draco_mesh_compression.js
+++ b/modules/gltf/src/lib/extensions/KHR_draco_mesh_compression.js
@@ -31,17 +31,6 @@ export default class KHR_draco_mesh_compression {
     scenegraph.removeExtension(KHR_DRACO_MESH_COMPRESSION);
   }
 
-  static decodeSync(gltfData, options) {
-    if (!options.decompress) {
-      return;
-    }
-    const scenegraph = new GLTFScenegraph(gltfData);
-    if (scenegraph.getRequiredExtension(KHR_DRACO_MESH_COMPRESSION)) {
-      throw new Error('Cannot synchronously decode Draco');
-    }
-    // TODO - we can support sync decoding, let's just keep code/bundle size in check...
-  }
-
   static encode(gltfData, options = {}) {
     const scenegraph = new GLTFScenegraph(gltfData);
 

--- a/modules/gltf/src/lib/extensions/gltf-extensions.js
+++ b/modules/gltf/src/lib/extensions/gltf-extensions.js
@@ -20,13 +20,3 @@ export async function decodeExtensions(gltf, options, context) {
     }
   }
 }
-
-export function decodeExtensionsSync(gltf, options, context) {
-  for (const extensionName in EXTENSIONS) {
-    const disableExtension = extensionName in options && !options[extensionName];
-    if (!disableExtension) {
-      const extension = EXTENSIONS[extensionName];
-      extension.decodeSync(gltf, options, context);
-    }
-  }
-}

--- a/modules/gltf/test/gltf-loader.spec.js
+++ b/modules/gltf/test/gltf-loader.spec.js
@@ -23,24 +23,14 @@ test('GLTFLoader#loader conformance', t => {
 
 // V2 parser
 
-test('GLTFLoader#parseSync(text/JSON)', async t => {
+test('GLTFLoader#parseSync()', async t => {
   const response = await fetchFile(GLTF_JSON_URL);
   const data = await response.text();
 
   t.throws(
     () => parseSync(data, GLTFLoader, {gltf: {parserVersion: 2}}),
-    'GLTFLoader throws when synchronously parsing gltfs with base64 buffers'
+    'GLTFLoader throws when synchronously parsing gltfs'
   );
-
-  t.end();
-});
-
-test('GLTFLoader#parseSync(binary)', async t => {
-  const response = await fetchFile(GLTF_BINARY_URL);
-  const data = await response.arrayBuffer();
-
-  const gltf = parseSync(data, GLTFLoader, {gltf: {parserVersion: 2}});
-  t.ok(gltf, 'GLTFLoader returned parsed data');
 
   t.end();
 });
@@ -58,26 +48,6 @@ test('GLTFLoader#load(text)', async t => {
 });
 
 // V1 parser (deprecated)
-
-test('GLTFLoader#parseSync(text/JSON) V1', async t => {
-  const response = await fetchFile(GLTF_JSON_URL);
-  const data = await response.text();
-
-  const gltf = parseSync(data, GLTFLoader);
-  t.ok(gltf, 'GLTFLoader returned parsed data');
-
-  t.end();
-});
-
-test('GLTFLoader#parseSync(binary) V1', async t => {
-  const response = await fetchFile(GLTF_BINARY_URL);
-  const data = await response.arrayBuffer();
-
-  const gltf = parseSync(data, GLTFLoader);
-  t.ok(gltf, 'GLTFLoader returned parsed data');
-
-  t.end();
-});
 
 test('GLTFLoader#load(binary) V1', async t => {
   const data = await load(GLTF_BINARY_URL, GLTFLoader);

--- a/modules/gltf/test/gltf-writer.spec.js
+++ b/modules/gltf/test/gltf-writer.spec.js
@@ -2,7 +2,7 @@
 import test from 'tape-promise/tape';
 import {validateWriter} from 'test/common/conformance';
 
-import {parseSync, encodeSync} from '@loaders.gl/core';
+import {parse, encodeSync} from '@loaders.gl/core';
 import {GLTFLoader, GLTFWriter, GLTFScenegraph, GLTFBuilder} from '@loaders.gl/gltf';
 
 const EXTRA_DATA = {extraData: 1};
@@ -19,7 +19,7 @@ test('GLTFWriter#loader conformance', t => {
   t.end();
 });
 
-test('GLTFWriter#encode', t => {
+test('GLTFWriter#encode', async t => {
   const gltfBuilder = new GLTFScenegraph();
   gltfBuilder.addApplicationData('viz', APP_DATA);
   gltfBuilder.addExtraData('test', EXTRA_DATA);
@@ -31,7 +31,7 @@ test('GLTFWriter#encode', t => {
 
   const arrayBuffer = encodeSync(gltfBuilder.gltf, GLTFWriter, {gltf: {parserVersion: 2}});
 
-  const gltf = parseSync(arrayBuffer, GLTFLoader, {gltf: {parserVersion: 2, postProcess: false}});
+  const gltf = await parse(arrayBuffer, GLTFLoader, {gltf: {parserVersion: 2, postProcess: false}});
   const gltfScenegraph = new GLTFScenegraph(gltf);
 
   const appData = gltfScenegraph.getApplicationData('viz');
@@ -53,7 +53,7 @@ test('GLTFWriter#encode', t => {
   t.end();
 });
 
-test('GLTFWriter#encode (DEPRECATED settings)', t => {
+test('GLTFWriter#encode (DEPRECATED settings)', async t => {
   const gltfBuilder = new GLTFBuilder();
   gltfBuilder.addApplicationData('viz', APP_DATA);
   gltfBuilder.addExtraData('test', EXTRA_DATA);
@@ -65,7 +65,7 @@ test('GLTFWriter#encode (DEPRECATED settings)', t => {
 
   const arrayBuffer = gltfBuilder.encodeSync();
 
-  const gltf = parseSync(arrayBuffer, GLTFLoader, {gltf: {parserVersion: 2, postProcess: false}});
+  const gltf = await parse(arrayBuffer, GLTFLoader, {gltf: {parserVersion: 2, postProcess: false}});
   const gltfScenegraph = new GLTFScenegraph(gltf);
 
   const appData = gltfScenegraph.getApplicationData('viz');

--- a/modules/gltf/test/lib/deprecated/gltf-parser.spec.js
+++ b/modules/gltf/test/lib/deprecated/gltf-parser.spec.js
@@ -1,7 +1,7 @@
 /* eslint-disable max-len */
 import test from 'tape-promise/tape';
 
-import {load, parse, parseSync, fetchFile} from '@loaders.gl/core';
+import {load, parse, fetchFile} from '@loaders.gl/core';
 import {GLTFLoader, GLBParser, GLTFParser} from '@loaders.gl/gltf';
 
 const GLTF_BINARY_URL = '@loaders.gl/gltf/test/data/gltf-2.0/2CylinderEngine.glb';

--- a/modules/gltf/test/lib/deprecated/gltf-parser.spec.js
+++ b/modules/gltf/test/lib/deprecated/gltf-parser.spec.js
@@ -1,7 +1,7 @@
 /* eslint-disable max-len */
 import test from 'tape-promise/tape';
 
-import {load, parseSync, fetchFile} from '@loaders.gl/core';
+import {load, parse, parseSync, fetchFile} from '@loaders.gl/core';
 import {GLTFLoader, GLBParser, GLTFParser} from '@loaders.gl/gltf';
 
 const GLTF_BINARY_URL = '@loaders.gl/gltf/test/data/gltf-2.0/2CylinderEngine.glb';
@@ -21,7 +21,7 @@ test('GLTFParser#parseSync(text/JSON)', async t => {
   const response = await fetchFile(GLTF_JSON_URL);
   const data = await response.text();
 
-  let gltf = parseSync(data, GLTFLoader);
+  let gltf = parse(data, GLTFLoader);
   t.ok(gltf, 'GLTFLoader returned parsed data');
 
   gltf = new GLTFParser().parseSync(data);
@@ -34,7 +34,7 @@ test('GLTFParser#parseSync(binary)', async t => {
   const response = await fetchFile(GLTF_BINARY_URL);
   const data = await response.arrayBuffer();
 
-  let gltf = parseSync(data, GLTFLoader);
+  let gltf = parse(data, GLTFLoader);
   t.ok(gltf, 'GLTFLoader returned parsed data');
 
   gltf = new GLTFParser().parseSync(data);

--- a/modules/kml/src/kml-as-geojson-loader.js
+++ b/modules/kml/src/kml-as-geojson-loader.js
@@ -37,5 +37,5 @@ export default {
   parseTextSync,
   browserOnly: true,
   worker: false,
-  DEFAULT_OPTIONS
+  options: DEFAULT_OPTIONS
 };

--- a/modules/ply/src/ply-loader.js
+++ b/modules/ply/src/ply-loader.js
@@ -18,5 +18,5 @@ export default {
   parse: async (arrayBuffer, options) => parsePLY(arrayBuffer, options), // TODO - this may not detect text correctly?
   parseTextSync: parsePLY,
   parseSync: parsePLY,
-  DEFAULT_OPTIONS
+  options: DEFAULT_OPTIONS
 };

--- a/modules/ply/src/ply-stream-loader.js
+++ b/modules/ply/src/ply-stream-loader.js
@@ -4,11 +4,9 @@
 
 import parsePLYStream from './lib/parse-ply-stream';
 
-const DEFAULT_OPTIONS = {};
-
 export default {
   name: 'PLY',
   extensions: ['ply'],
   parseStream: parsePLYStream,
-  DEFAULT_OPTIONS
+  options: {}
 };

--- a/website/package.json
+++ b/website/package.json
@@ -8,11 +8,11 @@
   ],
   "main": "index.js",
   "scripts": {
-    "start": "yarn clean-examples && yarn clean && yarn develop",
+    "start": "yarn clean && yarn develop",
     "build": "yarn clean-examples && yarn clean && gatsby build",
     "clean": "rm -rf ./.cache ./public",
     "clean-examples": "find ../examples -name node_modules -exec rm -r {} \\; || true",
-    "develop": "gatsby develop",
+    "develop": "yarn clean-examples && gatsby develop",
     "serve": "gatsby serve",
     "deploy": "NODE_DEBUG=gh-pages gh-pages -d public"
   },
@@ -41,7 +41,7 @@
     "gatsby": "^2.13.51",
     "gatsby-plugin-no-sourcemaps": "^2.0.2",
     "gh-pages": "^2.1.0",
-    "ocular-gatsby": "^1.0.0",
+    "ocular-gatsby": "^1.0.2",
     "sharp": "^0.23.0"
   }
 }


### PR DESCRIPTION
A big step towards getting the glTF loader into "reference quality" shape.

Trying hard to keep it backwards compatible when `options.gltf.parserVersion: 1` but it is getting harder...