### PR TITLE
Enable commented vis code

### DIFF
--- a/dev-docs/RFCs/README.md
+++ b/dev-docs/RFCs/README.md
@@ -15,12 +15,12 @@ Writeups of directions in major areas of interest
 | RFC                                                                  | Author   | Status    | Description                                   |
 | -------------------------------------------------------------------- | -------- | --------- | --------------------------------------------- |
 | [**Streaming JSON Loader**](v2.0/json-loader-rfc.md)                 | @ibgreen | **Draft** | Binary, streaming, worker-enabled JSON loader |
-| [**Loader Options**](v2.0/loader-options-rfc.md)                      | @ibgreen | **Draft** | Nested options scheme for loaders             |
+| [**Loader Options**](v2.0/loader-options-rfc.md)                     | @ibgreen | **Draft** | Nested options scheme for loaders             |
 | [**Fetch Options**](v2.0/fetch-option-rfc.md)                        | @ibgreen | **Draft** | Options for `fetch`                           |
 | [**JSON**](v2.0/json-support-rfc.md)                                 | @ibgreen | **Draft** | Core support for JSON formats                 |
 | [**Loader Auto-Detection**](v2.0/loader-auto-detection-rfc.md)       | @ibgreen | **Draft** | Improved support for loader auto detection    |
 | [**Loader Auto-Registration**](v2.0/loader-auto-registration-rfc.md) | @ibgreen | **Draft** | Loader auto registration at import            |
-| [**Loader Lookup By Name**](v2.0/loader-lookup-by-name-rfc.md)        | @ibgreen | **Draft** | Loader lookup among pre-registered loaders    |
+| [**Loader Lookup By Name**](v2.0/loader-lookup-by-name-rfc.md)       | @ibgreen | **Draft** | Loader lookup among pre-registered loaders    |
 
 ## v1.0 RFCs
 

--- a/dev-docs/RFCs/v2.0/fetch-option-rfc.md
+++ b/dev-docs/RFCs/v2.0/fetch-option-rfc.md
@@ -33,13 +33,11 @@ However, problems remain:
 - Some loaders (e.g. gltf) load additional files, currently they provide ad-hoc solutions for the "recursive" fetch operations.
 - (Update: This will no longer apply in v2) Some loaders (mainly image loaders) only support `load`. They do not support separate parsing of data, but instead load and parse in a single operation.
 
-
 ### Future considerations:
 
 - File system support (separate RFC) - Some loaders can generate virtual file systems (zip files, a list of dropped files in the browser, a dropbox loader) where files can be loaded with local names from a non-URL source. Overridable `fetch` in `load` and `parse` could be extended to support this.
 
 ## Proposals
-
 
 ## Proposal 1a: Allow fetch to be completely overridden
 

--- a/dev-docs/RFCs/v2.0/loader-auto-detection-rfc.md
+++ b/dev-docs/RFCs/v2.0/loader-auto-detection-rfc.md
@@ -23,6 +23,7 @@ Successful auto detection of loaders depends on multiple contextual pieces of in
 When autoselecting a loader, the `parse` (and sometimes `load`) functions should be supplied with contextual information.
 
 Depending on how `parse` is called, contextual information may be available:
+
 - The standard `fetch` `Response` object allows `url` and `headers` (in which MIME type might be present) to be queried.
 - The loaders.gl `fetchFile` function returns `fetch` `Response` objects for `File` and `Blob` objects, providing a uniform interface to such classes.
 

--- a/dev-docs/RFCs/v2.0/loader-auto-registration-rfc.md
+++ b/dev-docs/RFCs/v2.0/loader-auto-registration-rfc.md
@@ -9,8 +9,8 @@
 This RFC proposes that importing loaders.gl loader modules autoregisters their loaders, removing the need to also import and call `registerLoaders`.
 
 ## Review Notes
-- Sep 2019 - the `CompositeLoader` system is somewhat reducing the need to pre-register loaders.
 
+- Sep 2019 - the `CompositeLoader` system is somewhat reducing the need to pre-register loaders.
 
 ## Motivation
 
@@ -64,12 +64,11 @@ import '@loaders.gl/draco'; // Simply importing it makes this loader available
 new ScenegraphLayer({scenegraph: DRACO_COMPRESSED_GLTF_URL});
 ```
 
-
 ## Open Issues
 
 While loader "pre-registration" would be trivial to implement, there are some concerns:
 
-- Tree-shaking: A loader module often exports multiple loaders. By auto registering all of them, we  defeat tree-shaking (mitigated by the fact that we are already publishing loaders a-la-carte).
+- Tree-shaking: A loader module often exports multiple loaders. By auto registering all of them, we defeat tree-shaking (mitigated by the fact that we are already publishing loaders a-la-carte).
 - Which loader(s) to register: The default main-thread loader, the streaming loader, or the worker thread loader? All of them? Create separate entry-points for each of them?
 
 ```js
@@ -83,4 +82,3 @@ This would require solving non-trivial problems in ocular-dev-tools (which would
 - Increased dependency: Currently simple loader modules can be written without importing any loaders.gl helper libraries (e.g. `@loaders.gl/loader-utils`). If the loader modules have to import `registerLoaders` that changes. This is a design simplicity/elegance in loaders.gl that matters to some people, that would be lost for this convenience.
 - Manual registration code? - To avoid having to import `@loaders.gl/loader-utils` in each loader module, we could just ask each loader to push their loaders to a global array. But even then, the global scope must be determined, if not by helper functions in loaders.gl, then by some code that needs to be copied into each loader.
 - Conceptually, global mechanisms should normally be minimized.
-

--- a/modules/3d-tiles/src/lib/tileset/tileset-3d-traverser.js
+++ b/modules/3d-tiles/src/lib/tileset/tileset-3d-traverser.js
@@ -259,7 +259,6 @@ export default class Tileset3DTraverser {
         if (!child._inRequestVolume) {
           childRefines = false;
         } else if (!child.hasRenderContent) {
-          // childRefines = true; // this.executeEmptyTraversal(child, frameState);
           childRefines = this.executeEmptyTraversal(child, frameState);
         } else {
           childRefines = child.contentAvailable;

--- a/modules/3d-tiles/src/lib/tileset/tileset-3d-traverser.js
+++ b/modules/3d-tiles/src/lib/tileset/tileset-3d-traverser.js
@@ -2,7 +2,6 @@
 // See LICENSE.md and https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md
 
 import {TILE3D_REFINEMENT, TILE3D_OPTIMIZATION_HINT} from '../constants';
-// import {TILE3D_REFINEMENT} from '../constants';
 import ManagedArray from '../utils/managed-array';
 import assert from '../utils/assert';
 
@@ -244,11 +243,11 @@ export default class Tileset3DTraverser {
       tile.hasRenderContent;
     let refines = true;
 
-    let anyChildVisible = false;
+    let hasVisibleChild = false;
     for (const child of children) {
       if (child.isVisibleAndInRequestVolume) {
         stack.push(child);
-        anyChildVisible = true;
+        hasVisibleChild = true;
       } else if (checkRefines || options.loadSiblings) {
         // Keep non-visible children loaded since they are still needed before the parent can refine.
         // Or loadSiblings is true so always load tiles regardless of visibility.
@@ -269,7 +268,7 @@ export default class Tileset3DTraverser {
       }
     }
 
-    if (!anyChildVisible) {
+    if (!hasVisibleChild) {
       refines = false;
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1534,7 +1534,7 @@
     "@luma.gl/webgl2-polyfill" "7.3.0-beta.2"
     probe.gl "^3.1.0"
 
-"@math.gl/culling@^3.0.0-beta.3":
+"@math.gl/culling@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@math.gl/culling/-/culling-3.0.0.tgz#6ffb0b73cf4490568fe0961e8e902ea49d12447b"
   integrity sha512-g6l1We35RAisn+MDdvcukycyxsuNrYfzhElx7Xy4OObIiNlqRaPZvO4cZR++aabx5PN8xEIDs95HL59V+Vw6jQ==
@@ -1543,7 +1543,7 @@
     gl-matrix "^3.0.0"
     math.gl "3.0.0"
 
-"@math.gl/geospatial@^3.0.0-beta.3":
+"@math.gl/geospatial@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@math.gl/geospatial/-/geospatial-3.0.0.tgz#92708a4f6136d95d33d317bd255af055304f177d"
   integrity sha512-YeBdCRxe+Ql/C7RtxvCBtHYqz/423xarZxNqFIIzGNQFyQP8z9ETU+tewT7WL10XcZsjtqZToXoygzG0GUXzzw==
@@ -7533,10 +7533,17 @@ private@^0.1.6:
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
   integrity sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==
 
-probe.gl@3.1.0, probe.gl@^3.1.0, probe.gl@^3.1.0-beta.3:
+probe.gl@3.1.0, probe.gl@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/probe.gl/-/probe.gl-3.1.0.tgz#6aaeeb2d5bff85458fb7e8f7a72a57a53757c745"
   integrity sha512-Bqk+hMklRtHJ29UcDvhjh0ha0JLoZI5wpPBZdzAOwciBGhPXNy1C/TD1ihKBdOlCzTw78EKVLm0eKLj5Xek5+w==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+
+probe.gl@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/probe.gl/-/probe.gl-3.1.1.tgz#58f5d23efe588b9d9af10add6b47587f8e6c72b3"
+  integrity sha512-mD/DzhaYVftrRpobJd/W5JNhDVYCpClhuCGeOphuNZO1+qM6tOlBIf/6ETz11JyolZoJTTeT6aiVXOuIVyAVRg==
   dependencies:
     "@babel/runtime" "^7.0.0"
 


### PR DESCRIPTION
Uncomments some commented traversal code. This code was previously turned off to make hacked versions of traversal work when certain vis functionality was not yet working.

With this change, additive traversal works normally again (a parent no longer pulls all of its children, just the ones that it needs to). 

replacement refinement is still broken. When a tile is done processing off a worker, we should trigger a tileset update.