### PR TITLE
gltf: support KHR_materials_unlit extension

### DIFF
--- a/modules/gltf/docs/api-reference/gltf-extensions.md
+++ b/modules/gltf/docs/api-reference/gltf-extensions.md
@@ -10,7 +10,11 @@ Note that many glTF extensions affect aspects that are firmly outside of the sco
 | -------------------------------------------------------------------------------------------------------------------------------- | ----------- |
 | [KHR_draco_mesh_compression](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_draco_mesh_compression) |             |
 | [KHR_lights_punctual](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_lights_punctual)               |             |
+<<<<<<< HEAD
 | [KHR_materials_unlit](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_materials_unlit) | |
+=======
+| [KHR_materials_unlit](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_materials_unlit)               |             |
+>>>>>>> prettier
 
 ## Official Extensions
 

--- a/modules/gltf/docs/api-reference/gltf-extensions.md
+++ b/modules/gltf/docs/api-reference/gltf-extensions.md
@@ -10,11 +10,13 @@ Note that many glTF extensions affect aspects that are firmly outside of the sco
 | -------------------------------------------------------------------------------------------------------------------------------- | ----------- |
 | [KHR_draco_mesh_compression](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_draco_mesh_compression) |             |
 | [KHR_lights_punctual](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_lights_punctual)               |             |
+
 <<<<<<< HEAD
 | [KHR_materials_unlit](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_materials_unlit) | |
 =======
-| [KHR_materials_unlit](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_materials_unlit)               |             |
->>>>>>> prettier
+| [KHR_materials_unlit](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_materials_unlit) | |
+
+> > > > > > > prettier
 
 ## Official Extensions
 

--- a/modules/gltf/docs/api-reference/gltf-extensions.md
+++ b/modules/gltf/docs/api-reference/gltf-extensions.md
@@ -10,13 +10,7 @@ Note that many glTF extensions affect aspects that are firmly outside of the sco
 | -------------------------------------------------------------------------------------------------------------------------------- | ----------- |
 | [KHR_draco_mesh_compression](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_draco_mesh_compression) |             |
 | [KHR_lights_punctual](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_lights_punctual)               |             |
-
-<<<<<<< HEAD
-| [KHR_materials_unlit](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_materials_unlit) | |
-=======
-| [KHR_materials_unlit](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_materials_unlit) | |
-
-> > > > > > > prettier
+| [KHR_materials_unlit](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_materials_unlit)               |             |
 
 ## Official Extensions
 

--- a/modules/gltf/docs/api-reference/gltf-extensions.md
+++ b/modules/gltf/docs/api-reference/gltf-extensions.md
@@ -10,6 +10,7 @@ Note that many glTF extensions affect aspects that are firmly outside of the sco
 | -------------------------------------------------------------------------------------------------------------------------------- | ----------- |
 | [KHR_draco_mesh_compression](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_draco_mesh_compression) |             |
 | [KHR_lights_punctual](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_lights_punctual)               |             |
+| [KHR_materials_unlit](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_materials_unlit) | |
 
 ## Official Extensions
 
@@ -44,6 +45,12 @@ Parsing Support:
 Encoding Support:
 
 - N/A
+
+### KHR_materials_unlit
+
+Specifies that a material should not be affected by light. Useful for pre-lit materials (e.g. photogrammetry).
+
+[KHR_materials_unlit](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_materials_unlit)
 
 ## Custom Extensions
 

--- a/modules/gltf/src/lib/extensions/KHR_materials_unlit.js
+++ b/modules/gltf/src/lib/extensions/KHR_materials_unlit.js
@@ -18,7 +18,7 @@ export function decode(gltfData, options) {
     if (extension) {
       material.unlit = true;
     }
-    gltfScenegraph.removeObjectExtension(material, KHR_MATERIALS_UNLIT)
+    gltfScenegraph.removeObjectExtension(material, KHR_MATERIALS_UNLIT);
   }
 }
 

--- a/modules/gltf/src/lib/extensions/KHR_materials_unlit.js
+++ b/modules/gltf/src/lib/extensions/KHR_materials_unlit.js
@@ -1,0 +1,40 @@
+// GLTF EXTENSION: KHR_materials_unlit
+// https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_materials_unlit
+
+import GLTFScenegraph from '../gltf-scenegraph';
+import {KHR_MATERIALS_UNLIT} from '../gltf-constants';
+
+export function decode(gltfData, options) {
+  const gltfScenegraph = new GLTFScenegraph(gltfData);
+  const {json} = gltfScenegraph;
+
+  // Remove the top-level extension
+  gltfScenegraph.removeExtension(KHR_MATERIALS_UNLIT);
+
+  // Any nodes that have the extension, add lights field pointing to light object
+  // and remove the extension
+  for (const material of json.materials || []) {
+    const extension = material.extensions && material.extensions.KHR_materials_unlit;
+    if (extension) {
+      material.unlit = true;
+    }
+    gltfScenegraph.removeObjectExtension(material, KHR_MATERIALS_UNLIT)
+  }
+}
+
+export function encode(gltfData, options) {
+  const gltfScenegraph = new GLTFScenegraph(gltfData);
+  const {json} = gltfScenegraph;
+
+  // Any nodes that have lights field pointing to light object
+  // add the extension
+  if (gltfScenegraph.materials) {
+    for (const material of json.materials) {
+      if (material.unlit) {
+        delete material.unlit;
+        gltfScenegraph.addObjectExtension(material, KHR_MATERIALS_UNLIT);
+        gltfScenegraph.addExtensions(KHR_MATERIALS_UNLIT);
+      }
+    }
+  }
+}

--- a/modules/gltf/src/lib/extensions/gltf-extensions.js
+++ b/modules/gltf/src/lib/extensions/gltf-extensions.js
@@ -1,11 +1,13 @@
 /* eslint-disable camelcase */
 import * as KHR_draco_mesh_compression from './KHR_draco_mesh_compression';
 import * as KHR_lights_punctual from './KHR_lights_punctual';
+import * as KHR_materials_unlit from './KHR_materials_unlit';
 // import UBER_POINT_CLOUD_COMPRESSION from './KHR_draco_mesh_compression';
 
 export const EXTENSIONS = {
   KHR_draco_mesh_compression,
-  KHR_lights_punctual
+  KHR_lights_punctual,
+  KHR_materials_unlit
 };
 
 export async function decodeExtensions(gltf, options = {}, context) {

--- a/modules/gltf/test/index.js
+++ b/modules/gltf/test/index.js
@@ -11,6 +11,7 @@ import './lib/post-process-gltf.spec';
 
 import './lib/extensions/KHR_draco_mesh_compression.spec';
 import './lib/extensions/KHR_lights_punctual.spec';
+import './lib/extensions/KHR_materials_unlit.spec';
 
 import './glb-loader.spec';
 import './glb-writer.spec';

--- a/modules/gltf/test/lib/extensions/KHR_materials_unlit.spec.js
+++ b/modules/gltf/test/lib/extensions/KHR_materials_unlit.spec.js
@@ -1,0 +1,53 @@
+/* eslint-disable camelcase */
+import test from 'tape-promise/tape';
+
+import {decodeExtensions} from '@loaders.gl/gltf/lib/extensions/gltf-extensions.js';
+
+const TEST_CASES = [
+  {
+    name: 'KHR_materials_unlit',
+    input: {
+      json: {
+        extensionsUsed: ['KHR_materials_unlit'],
+        extensions: {
+          KHR_materials_unlit: {
+            lights: [
+              {
+                color: [1.0, 1.0, 1.0],
+                type: 'directional'
+              }
+            ]
+          }
+        },
+        materials: [
+          {
+            extensions: {
+              KHR_materials_unlit: {
+                light: 0
+              }
+            }
+          }
+        ]
+      }
+    },
+    output: {
+      extensionsUsed: [],
+      extensions: {},
+      materials: [
+        {
+          extensions: {},
+          unlit: true
+        }
+      ]
+    }
+  }
+];
+
+test('gltf#KHR_materials_unlit', async t => {
+  for (const testCase of TEST_CASES) {
+    await decodeExtensions(testCase.input);
+    // Modifies input
+    t.deepEqual(testCase.input.json, testCase.output, testCase.name);
+  }
+  t.end();
+});


### PR DESCRIPTION
@tsherif @jianhuang01 FYI - photogrammetry tiles are already lit and lighting needs to be disable for these tiles.

materials can now have an `unlit: true` field