### PR TITLE
3d-tilles: Add back NY example

### DIFF
--- a/examples/deck.gl/3d-tiles/components/control-panel.js
+++ b/examples/deck.gl/3d-tiles/components/control-panel.js
@@ -121,7 +121,7 @@ export default class ControlPanel extends PureComponent {
     return (
       <div style={{marginTop: '0.5cm'}}>
         <div style={{textAlign: 'center', borderStyle: 'groove'}}>
-          {Boolean(attributions.length) && <b>Tileset Credentials</b>}
+          {Boolean(attributions.length) && <b>Tileset Attribution</b>}
           {attributions.map(attribution => (
             <div key={attribution.html} dangerouslySetInnerHTML={{__html: attribution.html}} />
           ))}

--- a/examples/deck.gl/3d-tiles/examples.js
+++ b/examples/deck.gl/3d-tiles/examples.js
@@ -5,6 +5,8 @@ const ION_TOKEN_ST_HELEN =
   'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIxN2NhMzkwYi0zNWM4LTRjNTYtYWE3Mi1jMDAxYzhlOGVmNTAiLCJpZCI6OTYxOSwic2NvcGVzIjpbImFzbCIsImFzciIsImFzdyIsImdjIl0sImlhdCI6MTU2MjE4MTMxM30.OkgVr6NaKYxabUMIGqPOYFe0V5JifXLVLfpae63x-tA';
 const ION_TOKEN =
   'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJlYWMxMzcyYy0zZjJkLTQwODctODNlNi01MDRkZmMzMjIxOWIiLCJpZCI6OTYyMCwic2NvcGVzIjpbImFzbCIsImFzciIsImdjIl0sImlhdCI6MTU2Mjg2NjI3M30.1FNiClUyk00YH_nWfSGpiQAjR5V2OvREDq1PJ5QMjWQ';
+const ION_TOKEN_2 =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIzMGY4ODczYy1mNTk4LTRiMDUtYmIxYy0xZWYwOWZmMGY4NjQiLCJpZCI6NDQsInNjb3BlcyI6WyJhc3IiLCJnYyJdLCJhc3NldHMiOlsxLDIsMyw0LDYxOTMsNjI3Myw3MTYyLDczNTMsNzE0Ml0sImlhdCI6MTU0MTYxODM0NX0.lWnGs9ySXO4QK3HagcMsDpZ8L01DpmUDQm38-2QAQuE';
 
 const DATA_URI = 'https://raw.githubusercontent.com/uber-web/loaders.gl/master';
 const EXAMPLE_INDEX_URL = `${DATA_URI}/modules/3d-tiles/test/data/index.json`;
@@ -35,6 +37,10 @@ const ADDITIONAL_EXAMPLES = {
         ionAssetId: 44865,
         ionAccessToken:
           'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIwOTBkYTA1ZS03NGM5LTQyNTEtOTViOS1hZDFmNDZjZGQ3YTEiLCJpZCI6NDQsInNjb3BlcyI6WyJhc3IiXSwiYXNzZXRzIjpbNDQ4NjVdLCJpYXQiOjE1Njk0MTcwNjh9.zrWE65u2u-TYyTSRKhDl9-yDYrC_qxiJQ-tZFCgMbt0'
+      },
+      'New York (3D Photogrammetry)': {
+        ionAssetId: 7162,
+        ionAccessToken: ION_TOKEN_2
       }
     }
   },


### PR DESCRIPTION
All the chained loader plumbing is now in place, and the NY example now works perfectly, so temporarily adding it back while we are debugging.

However, none of the other b3dm tilesets work well, we'll need to understand what is different between these.