### PR TITLE
3d-tiles: Add Cesium sandbox example

### DIFF
--- a/examples/cesium/3d-tiles/app.js
+++ b/examples/cesium/3d-tiles/app.js
@@ -1,16 +1,15 @@
 /* global Cesium */
 
 Cesium.Ion.defaultAccessToken =
-  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiI4Y2RlNjczZi02MThlLTQxNGQtYmIxZC0wNjFiOWFhNDY2MzEiLCJpZCI6OTYxOSwic2NvcGVzIjpbImFzciIsImdjIl0sImlhdCI6MTU1NDQ4ODE1OH0.XIVcgLjGcA1HkJlUL-HMaiQfCoaSOrMPmnR7i1ScTyI";
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiI4Y2RlNjczZi02MThlLTQxNGQtYmIxZC0wNjFiOWFhNDY2MzEiLCJpZCI6OTYxOSwic2NvcGVzIjpbImFzciIsImdjIl0sImlhdCI6MTU1NDQ4ODE1OH0.XIVcgLjGcA1HkJlUL-HMaiQfCoaSOrMPmnR7i1ScTyI';
 
-const viewer = new Cesium.Viewer("cesiumContainer");
+const viewer = new Cesium.Viewer('cesiumContainer');
 
 const tileset = viewer.scene.primitives.add(
   new Cesium.Cesium3DTileset({
     url:
-      " https://raw.githubusercontent.com/uber-web/loaders.gl/master/modules/3d-tiles/test/data/Batched/BatchedColorsMix/tileset.json"
+      ' https://raw.githubusercontent.com/uber-web/loaders.gl/master/modules/3d-tiles/test/data/Batched/BatchedColorsMix/tileset.json'
   })
 );
 
 viewer.zoomTo(tileset);
-

--- a/examples/cesium/3d-tiles/app.js
+++ b/examples/cesium/3d-tiles/app.js
@@ -1,0 +1,16 @@
+/* global Cesium */
+
+Cesium.Ion.defaultAccessToken =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiI4Y2RlNjczZi02MThlLTQxNGQtYmIxZC0wNjFiOWFhNDY2MzEiLCJpZCI6OTYxOSwic2NvcGVzIjpbImFzciIsImdjIl0sImlhdCI6MTU1NDQ4ODE1OH0.XIVcgLjGcA1HkJlUL-HMaiQfCoaSOrMPmnR7i1ScTyI";
+
+const viewer = new Cesium.Viewer("cesiumContainer");
+
+const tileset = viewer.scene.primitives.add(
+  new Cesium.Cesium3DTileset({
+    url:
+      " https://raw.githubusercontent.com/uber-web/loaders.gl/master/modules/3d-tiles/test/data/Batched/BatchedColorsMix/tileset.json"
+  })
+);
+
+viewer.zoomTo(tileset);
+

--- a/examples/cesium/3d-tiles/index.html
+++ b/examples/cesium/3d-tiles/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <script src="https://cesiumjs.org/releases/1.60/Build/Cesium/Cesium.js"></script>
+    <link
+      href="https://cesiumjs.org/releases/1.60/Build/Cesium/Widgets/widgets.css"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div id="cesiumContainer" style="width: 100%; height:100%"></div>
+    <script type="module">
+      import './bundle.js';
+    </script>
+  </body>
+</html>

--- a/examples/cesium/3d-tiles/package.json
+++ b/examples/cesium/3d-tiles/package.json
@@ -1,0 +1,17 @@
+{
+  "license": "MIT",
+  "description": "Minimal example of using loaders.gl with Cesium.",
+  "scripts": {
+    "start": "webpack-dev-server --progress --hot --open -d"
+  },
+  "dependencies": {
+    "@loaders.gl/core": "^1.3.0",
+    "@loaders.gl/3d-tiles": "^1.3.0",
+    "@loaders.gl/draco": "^1.3.0"
+  },
+  "devDependencies": {
+    "html-webpack-plugin": "^3.2.0",
+    "webpack": "^4.3.0",
+    "webpack-dev-server": "^3.1.1"
+  }
+}

--- a/examples/cesium/3d-tiles/webpack.config.js
+++ b/examples/cesium/3d-tiles/webpack.config.js
@@ -1,0 +1,13 @@
+const {resolve} = require('path');
+
+module.exports = {
+  mode: 'development',
+
+  entry: {
+    bundle: resolve('./app.js')
+  } // ,
+
+  // externals: {
+  //   'Cesium'
+  // }
+};

--- a/examples/deck.gl/pointcloud/package.json
+++ b/examples/deck.gl/pointcloud/package.json
@@ -5,9 +5,9 @@
     "start-local": "webpack-dev-server --env.local --progress --hot --open"
   },
   "dependencies": {
-    "@loaders.gl/core": "^1.3.0-beta.1",
-    "@loaders.gl/las": "^1.3.0-beta.1",
-    "@loaders.gl/ply": "^1.3.0-beta.1",
+    "@loaders.gl/core": "^1.3.0",
+    "@loaders.gl/las": "^1.3.0",
+    "@loaders.gl/ply": "^1.3.0",
     "deck.gl": "^7.3.0-alpha.7",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",

--- a/examples/get-started-rollup/package.json
+++ b/examples/get-started-rollup/package.json
@@ -11,8 +11,8 @@
     "serve": "serve public"
   },
   "dependencies": {
-    "@loaders.gl/core": "^1.3.0-beta.1",
-    "@loaders.gl/obj": "^1.3.0-beta.1"
+    "@loaders.gl/core": "^1.3.0",
+    "@loaders.gl/obj": "^1.3.0"
   },
   "devDependencies": {
     "rollup": "^1.16.2",

--- a/examples/luma.gl/gltf/package.json
+++ b/examples/luma.gl/gltf/package.json
@@ -9,11 +9,11 @@
     "open-vr": "adb reverse tcp:8080 tcp:8080 && adb shell am start -a android.intent.action.VIEW -d http://localhost:8080/"
   },
   "dependencies": {
-    "@loaders.gl/core": "^1.3.0-beta.1",
-    "@loaders.gl/draco": "^1.3.0-beta.1",
-    "@luma.gl/addons": "^7.3.0-alpha.8",
-    "@luma.gl/constants": "^7.3.0-alpha.8",
-    "@luma.gl/core": "^7.3.0-alpha.8",
+    "@loaders.gl/core": "^1.3.0",
+    "@loaders.gl/draco": "^1.3.0",
+    "@luma.gl/addons": "^7.3.0",
+    "@luma.gl/constants": "^7.3.0",
+    "@luma.gl/core": "^7.3.0",
     "math.gl": "^3.0.0-beta.3"
   },
   "devDependencies": {

--- a/examples/progress/package.json
+++ b/examples/progress/package.json
@@ -6,8 +6,8 @@
     "start-local": "webpack-dev-server --env.local --progress --hot --open"
   },
   "dependencies": {
-    "@loaders.gl/core": "^1.2.2",
-    "@loaders.gl/obj": "^1.2.2"
+    "@loaders.gl/core": "^1.3.0",
+    "@loaders.gl/obj": "^1.3.0"
   },
   "devDependencies": {
     "html-webpack-plugin": "^3.2.0",


### PR DESCRIPTION
This is a port of @xintongxia 's [Code Sandbox](https://codesandbox.io/embed/static-kmd50) to the loaders.gl example structure.

My hope is that we can collaborate here on a Cesium integration that uses loaders.gl to load 3d-tiles.

At a minimum this will allow us to pinpoint bugs in the deck.gl/THREE.js integrations more clearly.

And also, this integration would allow you to evaluate a possible deeper adoptions of loaders.gl

<img width="805" alt="Screen Shot 2019-09-27 at 8 15 29 AM" src="https://user-images.githubusercontent.com/7025232/65780657-0d8ae700-e0ff-11e9-9487-f01ab77e82c5.png">
