### PR TITLE
Import workers from url

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -4,7 +4,7 @@ module.exports = api => {
   const config = getBabelConfig(api);
 
   config.plugins = config.plugins || [];
-  config.plugins.push([
+  config.plugins.push('version-inline', [
     'babel-plugin-inline-import',
     {
       extensions: ['.worker.js']

--- a/examples/webpack.config.local.js
+++ b/examples/webpack.config.local.js
@@ -108,7 +108,12 @@ const LOCAL_DEVELOPMENT_CONFIG = {
     ]
   },
 
-  plugins: [new webpack.EnvironmentPlugin(['MapboxAccessToken'])]
+  plugins: [
+    new webpack.EnvironmentPlugin(['MapboxAccessToken']),
+    new webpack.DefinePlugin({
+      __VERSION__: JSON.stringify('latest')
+    })
+  ]
 };
 
 function addLocalDependency(config, dependency) {

--- a/modules/arrow/src/arrow-worker-loader.js
+++ b/modules/arrow/src/arrow-worker-loader.js
@@ -1,10 +1,11 @@
-// The bundled worker is imported as an inline string
-import worker from '../dist/arrow-loader.worker.js';
-
+/* global __VERSION__ */
 export default {
   name: 'Apache Arrow',
   extensions: ['arrow'],
   mimeType: 'application/octet-stream',
   category: 'table',
-  worker
+  worker: true,
+  defaultOptions: {
+    workerUrl: `https://unpkg.com/@loaders.gl/arrow@${__VERSION__}/dist/arrow-loader.worker.js`
+  }
 };

--- a/modules/arrow/src/arrow-worker-loader.js
+++ b/modules/arrow/src/arrow-worker-loader.js
@@ -1,4 +1,3 @@
-/* global __VERSION__ */
 export default {
   name: 'Apache Arrow',
   extensions: ['arrow'],
@@ -6,6 +5,8 @@ export default {
   category: 'table',
   worker: true,
   defaultOptions: {
+    /* global __VERSION__ */
+    // __VERSION__ is injected by babel-plugin-version-inline
     workerUrl: `https://unpkg.com/@loaders.gl/arrow@${__VERSION__}/dist/arrow-loader.worker.js`
   }
 };

--- a/modules/arrow/test/arrow-loader.spec.js
+++ b/modules/arrow/test/arrow-loader.spec.js
@@ -56,7 +56,9 @@ test('ArrowLoader#parse (WORKER)', async t => {
     return;
   }
 
-  const data = await parse(fetchFile(ARROW_SIMPLE), ArrowWorkerLoader);
+  const data = await parse(fetchFile(ARROW_SIMPLE), ArrowWorkerLoader, {
+    workerUrl: 'modules/arrow/dist/arrow-loader.worker.js'
+  });
   t.ok(data, 'Data returned');
   t.end();
 });

--- a/modules/core/src/lib/loader-utils/parse-with-worker.js
+++ b/modules/core/src/lib/loader-utils/parse-with-worker.js
@@ -58,6 +58,19 @@ export default function parseWithWorker(
   options = {},
   context = {}
 ) {
+  if (workerSource === true) {
+    if (options.workerUrl.startsWith('http')) {
+      workerSource = `
+  try {
+    importScripts('${options.workerUrl}')
+  } catch (error) {
+    console.error(error);
+  }`;
+    } else {
+      workerSource = `url(${options.workerUrl})`;
+    }
+  }
+
   const workerFarm = getWorkerFarm(options);
 
   // options.log object contains functions which cannot be transferred

--- a/modules/core/src/lib/loader-utils/parse-with-worker.js
+++ b/modules/core/src/lib/loader-utils/parse-with-worker.js
@@ -58,8 +58,10 @@ export default function parseWithWorker(
   options = {},
   context = {}
 ) {
-  if (workerSource === true) {
+  if (options.workerUrl) {
     if (options.workerUrl.startsWith('http')) {
+      // Per spec worker cannot be constructed from a different origin
+      // Only use trusted sources!
       workerSource = `
   try {
     importScripts('${options.workerUrl}')

--- a/modules/core/test/worker-utils/worker-farm.spec.js
+++ b/modules/core/test/worker-utils/worker-farm.spec.js
@@ -1,4 +1,4 @@
-/* global Worker */
+/* global Worker,location */
 import test from 'tape-catch';
 import {_WorkerThread, _WorkerPool, toArrayBuffer} from '@loaders.gl/core';
 import parseWithWorker from '@loaders.gl/core/lib/loader-utils/parse-with-worker';
@@ -135,6 +135,36 @@ test('createWorker#nested', async t => {
   t.deepEquals(result[1], TEST_CASES[1], 'worker returns expected result');
 
   _unregisterLoaders();
+
+  t.end();
+});
+
+test('parseWithWorker#options.workerUrl', async t => {
+  if (!hasWorker) {
+    t.comment('Worker test is browser only');
+    t.end();
+    return;
+  }
+
+  const testData = [{chunk: 0}, {chunk: 1}, {chunk: 2}];
+
+  let parsedData = await parseWithWorker(
+    true,
+    'test-json-loader',
+    toArrayBuffer(JSON.stringify(testData)),
+    {workerUrl: './json-loader.worker.js'}
+  );
+
+  t.deepEquals(parsedData, testData, 'data parsed with relative worker url');
+
+  parsedData = await parseWithWorker(
+    true,
+    'test-json-loader',
+    toArrayBuffer(JSON.stringify(testData)),
+    {workerUrl: `${location.origin}/json-loader.worker.js`}
+  );
+
+  t.deepEquals(parsedData, testData, 'data parsed with absolute worker url');
 
   t.end();
 });

--- a/modules/draco/src/draco-worker-loader.js
+++ b/modules/draco/src/draco-worker-loader.js
@@ -1,4 +1,3 @@
-/* global __VERSION__ */
 export default {
   name: 'DRACO',
   extensions: ['drc'],
@@ -6,6 +5,8 @@ export default {
   test: 'DRACO',
   worker: true,
   defaultOptions: {
+    /* global __VERSION__ */
+    // __VERSION__ is injected by babel-plugin-version-inline
     workerUrl: `https://unpkg.com/@loaders.gl/draco@${__VERSION__}/dist/draco-loader.worker.js`
   }
 };

--- a/modules/draco/src/draco-worker-loader.js
+++ b/modules/draco/src/draco-worker-loader.js
@@ -1,10 +1,11 @@
-// The bundled worker is imported as an inline string
-import worker from '../dist/draco-loader.worker.js';
-
+/* global __VERSION__ */
 export default {
   name: 'DRACO',
   extensions: ['drc'],
   binary: true,
   test: 'DRACO',
-  worker
+  worker: true,
+  defaultOptions: {
+    workerUrl: `https://unpkg.com/@loaders.gl/draco@${__VERSION__}/dist/draco-loader.worker.js`
+  }
 };

--- a/modules/draco/test/draco-loader.spec.js
+++ b/modules/draco/test/draco-loader.spec.js
@@ -28,7 +28,9 @@ test('DracoWorkerLoader#parse', async t => {
     return;
   }
 
-  const data = await load(BUNNY_DRC_URL, DracoWorkerLoader);
+  const data = await load(BUNNY_DRC_URL, DracoWorkerLoader, {
+    workerUrl: 'modules/draco/dist/draco-loader.worker.js'
+  });
   validatePointCloudCategoryData(t, data);
   t.equal(data.attributes.POSITION.value.length, 104502, 'POSITION attribute was found');
 

--- a/modules/las/src/las-worker-loader.js
+++ b/modules/las/src/las-worker-loader.js
@@ -1,8 +1,9 @@
-// The bundled worker is imported as an inline string
-import worker from '../dist/las-loader.worker.js';
-
+/* global __VERSION__ */
 export default {
   name: 'LAZ',
   extensions: ['las', 'laz'],
-  worker
+  worker: true,
+  defaultOptions: {
+    workerUrl: `https://unpkg.com/@loaders.gl/las@${__VERSION__}/dist/las-loader.worker.js`
+  }
 };

--- a/modules/las/src/las-worker-loader.js
+++ b/modules/las/src/las-worker-loader.js
@@ -1,9 +1,10 @@
-/* global __VERSION__ */
 export default {
   name: 'LAZ',
   extensions: ['las', 'laz'],
   worker: true,
   defaultOptions: {
+    /* global __VERSION__ */
+    // __VERSION__ is injected by babel-plugin-version-inline
     workerUrl: `https://unpkg.com/@loaders.gl/las@${__VERSION__}/dist/las-loader.worker.js`
   }
 };

--- a/modules/las/test/las-loader.spec.js
+++ b/modules/las/test/las-loader.spec.js
@@ -33,7 +33,10 @@ test('LASWorkerLoader#parseBinary', async t => {
     return;
   }
 
-  const data = await load(LAS_BINARY_URL, LASWorkerLoader, {skip: 10});
+  const data = await load(LAS_BINARY_URL, LASWorkerLoader, {
+    workerUrl: 'modules/las/dist/las-loader.worker.js',
+    skip: 10
+  });
   validatePointCloudCategoryData(t, data);
 
   t.equal(data.attributes.POSITION.value.length, 80805 * 3, 'POSITION attribute was found');

--- a/modules/obj/src/obj-worker-loader.js
+++ b/modules/obj/src/obj-worker-loader.js
@@ -1,9 +1,10 @@
-/* global __VERSION__ */
 export default {
   name: 'OBJ',
   extensions: ['obj'],
   worker: true,
   defaultOptions: {
+    /* global __VERSION__ */
+    // __VERSION__ is injected by babel-plugin-version-inline
     workerUrl: `https://unpkg.com/@loaders.gl/obj@${__VERSION__}/dist/obj-loader.worker.js`
   }
 };

--- a/modules/obj/src/obj-worker-loader.js
+++ b/modules/obj/src/obj-worker-loader.js
@@ -1,8 +1,8 @@
-// The bundled worker is imported as an inline string
-import worker from '../dist/obj-loader.worker.js';
-
 export default {
   name: 'OBJ',
   extensions: ['obj'],
-  worker
+  worker: true,
+  defaultOptions: {
+    workerUrl: 'https://unpkg.com/@loaders.gl/obj/dist/obj-loader.worker.js'
+  }
 };

--- a/modules/obj/src/obj-worker-loader.js
+++ b/modules/obj/src/obj-worker-loader.js
@@ -1,8 +1,9 @@
+/* global __VERSION__ */
 export default {
   name: 'OBJ',
   extensions: ['obj'],
   worker: true,
   defaultOptions: {
-    workerUrl: 'https://unpkg.com/@loaders.gl/obj/dist/obj-loader.worker.js'
+    workerUrl: `https://unpkg.com/@loaders.gl/obj@${__VERSION__}/dist/obj-loader.worker.js`
   }
 };

--- a/modules/obj/test/obj-loader.spec.js
+++ b/modules/obj/test/obj-loader.spec.js
@@ -55,7 +55,9 @@ test('OBJWorkerLoader#parse(text)', async t => {
     return;
   }
 
-  const data = await load(OBJ_ASCII_URL, OBJWorkerLoader);
+  const data = await load(OBJ_ASCII_URL, OBJWorkerLoader, {
+    workerUrl: 'modules/obj/dist/obj-loader.worker.js'
+  });
 
   validatePointCloudCategoryData(t, data);
 

--- a/modules/pcd/src/pcd-worker-loader.js
+++ b/modules/pcd/src/pcd-worker-loader.js
@@ -1,8 +1,9 @@
-// The bundled worker is imported as an inline string
-import worker from '../dist/pcd-loader.worker.js';
-
+/* global __VERSION__ */
 export default {
   name: 'PCD',
   extensions: ['pcd'],
-  worker
+  worker: true,
+  defaultOptions: {
+    workerUrl: `https://unpkg.com/@loaders.gl/pcd@${__VERSION__}/dist/pcd-loader.worker.js`
+  }
 };

--- a/modules/pcd/src/pcd-worker-loader.js
+++ b/modules/pcd/src/pcd-worker-loader.js
@@ -1,9 +1,10 @@
-/* global __VERSION__ */
 export default {
   name: 'PCD',
   extensions: ['pcd'],
   worker: true,
   defaultOptions: {
+    /* global __VERSION__ */
+    // __VERSION__ is injected by babel-plugin-version-inline
     workerUrl: `https://unpkg.com/@loaders.gl/pcd@${__VERSION__}/dist/pcd-loader.worker.js`
   }
 };

--- a/modules/pcd/test/pcd-loader.spec.js
+++ b/modules/pcd/test/pcd-loader.spec.js
@@ -45,7 +45,9 @@ test('PCDWorkerLoader#parse(binary)', async t => {
     return;
   }
 
-  const data = await load(PCD_BINARY_URL, PCDWorkerLoader);
+  const data = await load(PCD_BINARY_URL, PCDWorkerLoader, {
+    workerUrl: 'modules/pcd/dist/pcd-loader.worker.js'
+  });
   validatePointCloudCategoryData(t, data);
 
   t.equal(data.mode, 0, 'mode is POINTS (0)');

--- a/modules/ply/src/ply-worker-loader.js
+++ b/modules/ply/src/ply-worker-loader.js
@@ -1,11 +1,12 @@
-// The bundled worker is imported as an inline string
-import worker from '../dist/ply-loader.worker.js';
-
+/* global __VERSION__ */
 export default {
   name: 'PLY',
   extensions: ['ply'],
   text: true,
   binary: true,
   test: 'ply',
-  worker
+  worker: true,
+  defaultOptions: {
+    workerUrl: `https://unpkg.com/@loaders.gl/ply@${__VERSION__}/dist/ply-loader.worker.js`
+  }
 };

--- a/modules/ply/src/ply-worker-loader.js
+++ b/modules/ply/src/ply-worker-loader.js
@@ -1,4 +1,3 @@
-/* global __VERSION__ */
 export default {
   name: 'PLY',
   extensions: ['ply'],
@@ -7,6 +6,8 @@ export default {
   test: 'ply',
   worker: true,
   defaultOptions: {
+    /* global __VERSION__ */
+    // __VERSION__ is injected by babel-plugin-version-inline
     workerUrl: `https://unpkg.com/@loaders.gl/ply@${__VERSION__}/dist/ply-loader.worker.js`
   }
 };

--- a/modules/ply/test/ply-loader.spec.js
+++ b/modules/ply/test/ply-loader.spec.js
@@ -62,7 +62,9 @@ test('PLYLoader#parse(WORKER)', async t => {
     return;
   }
 
-  const data = await load(PLY_BUN_ZIPPER_URL, PLYWorkerLoader);
+  const data = await load(PLY_BUN_ZIPPER_URL, PLYWorkerLoader, {
+    workerUrl: 'modules/ply/dist/ply-loader.worker.js'
+  });
 
   validatePointCloudCategoryData(t, data);
   t.equal(data.attributes.POSITION.value.length, 107841, 'POSITION attribute was found');

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "cover": "ocular-test cover",
     "lint": "ocular-lint",
     "publish": "ocular-publish",
+    "prepare": "npm run build",
     "test": "ocular-test",
     "test-fast": "ocular-test fast",
     "test-browser": "ocular-test browser",

--- a/test/browser.js
+++ b/test/browser.js
@@ -21,10 +21,15 @@
 // TODO - this interferes with render test by adding background color
 // require('tap-browser-color')();
 
+/* global window */
 const test = require('tape');
 
 test.onFinish(window.browserTestDriver_finish);
 test.onFailure(window.browserTestDriver_fail);
+
+// This constant will be inlined by babel plugin.
+// To test source without transpilation, set a fallback here.
+window.__VERSION__ = 'latest';
 
 test('Browser tests', t => {
   require('./modules');

--- a/test/node.js
+++ b/test/node.js
@@ -10,6 +10,9 @@ if (typeof process !== 'undefined') {
   // console.log(matches, version);
 }
 
+// This constant will be inlined by babel plugin.
+// To test source without transpilation, set a fallback here.
+global.__VERSION__ = 'latest';
 global.nodeVersion = version;
 
 if (version < 10) {


### PR DESCRIPTION
Currently the `*WorkerLoader`s embed worker source as strings. This approach introduced the following issues:

- Re-distributing external modules - some loaders contain large external components such as Draco and LAZ. These components do not change with each loaders.gl version but we need to re-bundle them as part of the worker.
- Bundle size - large workers inflate application bundles significantly. Users do not have the choice to split the worker from the app bundle.
- Duplication - When a loader module's standalone bundle is created, the large components are included twice, once in the main thread version, once in the worker as an inline string.

This PR is the first step towards addressing these issues:

- The worker source is separated from the `*WorkerLoader`s and by default loaded from CDN. It significantly reduces the footprint of the worker loaders.
- It provides the option for users to host the worker as a static file on their own server.