### PR TITLE
lerna: Start 2.0.0-alpha track

### DIFF
--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -11,7 +11,6 @@
 - `ImageHTMLLoader` and `ImageHTMLLoader` removed. Use `options.images.format: 'html'` or `options.images.format: 'imagebitmap'` to control the output type.
 - `loadImage(url, options)` removed. Use `load(url, ImageLoader, options)` instead.
 
-
 ## Upgrading from v1.2 to v1.3
 
 - As with v1.1, `GLTFLoader` will no longer return a `GLTFParser` object in v2.0. A new option `options.gltf.parserVersion: 2` is provided to opt in to the new behavior now.

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -1,5 +1,17 @@
 # Upgrade Guide
 
+## Upgrading from v1.3 to v2.0
+
+### `@loaders.gl/core`:
+
+- Loaders no longer have a `loadAndParse` removed. Just define `parse` on your loaders.
+
+### `@loaders.gl/images`:
+
+- `ImageHTMLLoader` and `ImageHTMLLoader` removed. Use `options.images.format: 'html'` or `options.images.format: 'imagebitmap'` to control the output type.
+- `loadImage(url, options)` removed. Use `load(url, ImageLoader, options)` instead.
+
+
 ## Upgrading from v1.2 to v1.3
 
 - As with v1.1, `GLTFLoader` will no longer return a `GLTFParser` object in v2.0. A new option `options.gltf.parserVersion: 2` is provided to opt in to the new behavior now.

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -23,12 +23,14 @@ The 2.0 release brings stronger loader composition, image loading improvements, 
 ### @loaders.gl/images
 
 - **Image Category** now defined
+
   - Category ensures interchangability
   - Composite loader (Array) `ImageLoaders` for easy registration.
   - No longer uses `loadAndParse`,
   - Node.js support improved.
 
 - `options.image` contain common options that apply across the category
+
   - `options.image.format`, Ability to control loaded image format, default `auto`
   - TBA `options.image.useWorkers: true` - Worker Image Loaders on Chrome and Firefox
   - TBA `options.image.decodeHTML: true` - Support for `Image.decode()` to ensure HTML images are ready to be used when loader promise resolves.

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -1,27 +1,13 @@
 # What's New
 
-## v2.0 (no release available, experimental parts accessible in v1.4-alpha)
+## v2.0 (In development)
+
+Release Date: Target mid-Nov, 2019, currently available as `2.0.0-alpha` releases
+
+The 2.0 release brings stronger loader composition, image loading improvements, significant overhauls to several loaders and removes deprecated functions across the board.
 
 - `@loaders.gl/images`: Redefined as a new Image Category, see below
 - `@loaders.gl/core`: `loader.loadAndParse` removed.
-
-### @loaders.gl/images
-
-- **Image Category** now defined
-  - Now have a separate micro loader for each format: `JPEGLoader`, `PNGLoader`, `GIFLoader`, `BMPLoader`, `SVGLoader`
-  - Category ensures interchangability
-  - Composite loader (Array) `ImageLoaders` for easy registration.
-  - No longer uses `loadAndParse`, even loads from URLs are blobified and object URL:ed.
-- `options.image` contain common options that apply across the category
-  - Ability to control loaded image format `options.image.format`, default `auto`
-  - Worker Image Loaders on Chrome and Firefox `options.image.useWorkers: true`
-  - Support for `Image.decode()` to ensure images are ready to go when loader promise resolves: `options.image.decodeHTML: true`
-
-## v1.4 (In Development)
-
-Release Date: Target mid-Nov, 2019 (alpha/beta releases will soon become available)
-
-The 1.4 release starts to introduce loaders.gl 2.0 concepts.
 
 ### @loaders.gl/core
 
@@ -33,6 +19,21 @@ The 1.4 release starts to introduce loaders.gl 2.0 concepts.
 - **Composite Loaders**
 
   - Loaders can call other loaders
+
+### @loaders.gl/images
+
+- **Image Category** now defined
+  - Category ensures interchangability
+  - Composite loader (Array) `ImageLoaders` for easy registration.
+  - No longer uses `loadAndParse`,
+  - Node.js support improved.
+
+- `options.image` contain common options that apply across the category
+  - `options.image.format`, Ability to control loaded image format, default `auto`
+  - TBA `options.image.useWorkers: true` - Worker Image Loaders on Chrome and Firefox
+  - TBA `options.image.decodeHTML: true` - Support for `Image.decode()` to ensure HTML images are ready to be used when loader promise resolves.
+
+  - TBD: Now have a separate micro loader for each format: `JPEGLoader`, `PNGLoader`, `GIFLoader`, `BMPLoader`, `SVGLoader`
 
 ## v1.3
 

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "2.9.1",
-  "version": "1.3.0",
+  "version": "2.0.0-alpha.0",
   "command": {
     "publish": {},
     "bootstrap": {}


### PR DESCRIPTION
- Lots of big and potentially breaking changes going in => major bump prudent
- Lots of deprecated code (we have 2 complete glTFLoaders) => major bump allows removal