### PR TITLE
core: Avoid binding context due to transpilation issues

### DIFF
--- a/modules/3d-tiles/src/lib/parsers/helpers/parse-3d-tile-gltf-view.js
+++ b/modules/3d-tiles/src/lib/parsers/helpers/parse-3d-tile-gltf-view.js
@@ -60,10 +60,15 @@ export async function extractGLTF(tile, gltfFormat, options, context) {
     }
     if (tile.gltfArrayBuffer) {
       // TODO - Should handle byteOffset... However, not used now...
-      tile.gltf = await parse(tile.gltfArrayBuffer, GLTFLoader, {
-        ...options,
-        gltf: {parserVersion: 2}
-      });
+      tile.gltf = await parse(
+        tile.gltfArrayBuffer,
+        GLTFLoader,
+        {
+          ...options,
+          gltf: {parserVersion: 2}
+        },
+        context
+      );
       delete tile.gltfArrayBuffer;
       delete tile.gltfByteOffset;
       delete tile.gltfByteLength;
@@ -78,10 +83,15 @@ export function extractGLTFSync(tile, gltfFormat, options, context) {
     if (tile.gltfArrayBuffer) {
       const {parseSync} = context;
       // TODO - Should handle byteOffset... Not used now...
-      tile.gltf = parseSync(tile.gltfArrayBuffer, GLTFLoader, {
-        ...options,
-        gltf: {parserVersion: 2}
-      });
+      tile.gltf = parseSync(
+        tile.gltfArrayBuffer,
+        GLTFLoader,
+        {
+          ...options,
+          gltf: {parserVersion: 2}
+        },
+        context
+      );
       delete tile.gltfArrayBuffer;
       delete tile.gltfByteOffset;
       delete tile.gltfByteLength;

--- a/modules/3d-tiles/src/lib/parsers/parse-3d-tile-point-cloud.js
+++ b/modules/3d-tiles/src/lib/parsers/parse-3d-tile-point-cloud.js
@@ -200,7 +200,7 @@ async function parseDraco(tile, featureTable, batchTable, options, context) {
 // eslint-disable-next-line complexity, max-statements
 export async function loadDraco(tile, dracoData, options, context) {
   const {parse} = context;
-  const data = await parse(dracoData.buffer);
+  const data = await parse(dracoData.buffer, {});
 
   const decodedPositions = data.attributes.POSITION && data.attributes.POSITION.value;
   const decodedColors = data.attributes.COLOR_0 && data.attributes.COLOR_0.value;

--- a/modules/core/src/lib/loader-utils/get-loader-context.js
+++ b/modules/core/src/lib/loader-utils/get-loader-context.js
@@ -19,20 +19,6 @@ export function getLoaderContext(context, options, previousContext) {
     context.loaders = null;
   }
 
-  // Make context available to parse functions by binding it to `this`
-  if (context.parse) {
-    context.parse = context.parse.bind(context);
-  }
-  if (context.parseSync) {
-    context.parseSync = context.parseSync.bind(context);
-  }
-  if (context.parseInBatches) {
-    context.parseInBatches = context.parseInBatches.bind(context);
-  }
-  if (context.parseInBatchesSync) {
-    context.parseInBatchesSync = context.parseSync.bind(context);
-  }
-
   return context;
 }
 

--- a/modules/core/src/lib/parse-sync.js
+++ b/modules/core/src/lib/parse-sync.js
@@ -4,20 +4,23 @@ import {mergeOptions} from './loader-utils/merge-options';
 import {getArrayBufferOrStringFromDataSync} from './loader-utils/get-data';
 import {getLoaders, getLoaderContext} from './loader-utils/get-loader-context';
 
-export function parseSync(data, loaders, options, url) {
+export function parseSync(data, loaders, options, context) {
   // Signature: parseSync(data, options, url)
   // Uses registered loaders
   if (!Array.isArray(loaders) && !isLoaderObject(loaders)) {
-    url = options;
+    context = options;
     options = loaders;
     loaders = null;
   }
 
-  options = options || {};
+  // DEPRECATED - backwards compatibility, last param can be URL...
+  let url;
+  if (typeof context === 'string') {
+    url = context;
+    context = null;
+  }
 
-  // We store the context in `this` using bind for "recursive" parse calls
-  // eslint-disable-next-line consistent-this, no-invalid-this
-  let context = this;
+  options = options || {};
 
   // Chooses a loader (and normalizes it)
   // Also use any loaders in the context, new loaders take priority

--- a/modules/core/src/lib/parse.js
+++ b/modules/core/src/lib/parse.js
@@ -7,20 +7,23 @@ import {getLoaders, getLoaderContext} from './loader-utils/get-loader-context';
 import parseWithWorker from './loader-utils/parse-with-worker';
 import {selectLoader} from './select-loader';
 
-export async function parse(data, loaders, options, url) {
-  // Signature: parse(data, options, url)
+export async function parse(data, loaders, options, context) {
+  // Signature: parse(data, options, context | url)
   // Uses registered loaders
-  if (loaders && !Array.isArray(loaders) && !isLoaderObject(loaders)) {
-    url = options;
+  if (!Array.isArray(loaders) && !isLoaderObject(loaders)) {
+    context = options;
     options = loaders;
     loaders = null;
   }
 
-  options = options || {};
+  // DEPRECATED - backwards compatibility, last param can be URL...
+  let url;
+  if (typeof context === 'string') {
+    url = context;
+    context = null;
+  }
 
-  // We store the context in `this` using bind for "recursive" parse calls
-  // eslint-disable-next-line consistent-this, no-invalid-this
-  let context = this;
+  options = options || {};
 
   // Extract a url for auto detection
   const autoUrl = getUrlFromData(data, url);


### PR DESCRIPTION
For some reason the bind version of the context code fails in transpiled tests and under Node 8.