### PR TITLE
Add b3dm loading to CesiumJS example

### DIFF
--- a/examples/cesium/3d-tiles/app.js
+++ b/examples/cesium/3d-tiles/app.js
@@ -1,128 +1,74 @@
-/* global Cesium, fetch */
-
-import {Vector3} from 'math.gl';
-import {registerLoaders, setLoaderOptions} from '@loaders.gl/core';
-import {DracoLoader} from '@loaders.gl/draco';
-import {Tileset3D, _getIonTilesetMetadata} from '@loaders.gl/3d-tiles';
-import {Plane} from '@math.gl/culling';
-import {loadBatchedModelTile, loadPointTile} from './tile-parsers';
-
-// set up loaders
-registerLoaders([DracoLoader]);
-setLoaderOptions({worker: false});
+/* global Cesium, document  */
+import {loadTileset} from './tileset-loader';
 
 // This is taken from this blog: https://cesium.com/blog/2019/08/06/webodm-ships-with-cesium-ion/
 // Data captured by American Red Cross.
+/* eslint-disable no-unused-vars */
 const malalisonToken =
   'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiI0MTQ0NTNiOC0wNzlmLTQ1ZGEtYjM3Yi05ZmJlY2FiMmRjYWMiLCJpZCI6MTMxNTEsInNjb3BlcyI6WyJhc3IiLCJnYyJdLCJpYXQiOjE1NjI2OTQ3NTh9.tlqEVzzO25Itcla4jD17yywNFvAVM-aNVduzF6ss-1g';
-
-// Ion assets
 Cesium.Ion.defaultAccessToken =
   'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJlYWMxMzcyYy0zZjJkLTQwODctODNlNi01MDRkZmMzMjIxOWIiLCJpZCI6OTYyMCwic2NvcGVzIjpbImFzbCIsImFzciIsImdjIl0sImlhdCI6MTU2Mjg2NjI3M30.1FNiClUyk00YH_nWfSGpiQAjR5V2OvREDq1PJ5QMjWQ';
-const MELBOURNE_ION_ASSET_ID = 43978; // eslint-disable-line
-const CAIRO_ASSET_ID = 29328; // eslint-disable-line
+const MELBOURNE_ION_ASSET_ID = 43978;
+const CAIRO_ASSET_ID = 29328;
 const MALALISON_ISLAND_ASSET_ID = 34014;
+/* eslint-enable no-unused-vars */
+const VIEW_TYPES = {SINGLE: 0, SIDE_BY_SIDE: 1};
 
-// const VIEW_TYPES = {SINGLE: 0, SIDE_BY_SIDE: 1};
-// const VIEW_MODE = VIEW_TYPES.SINGLE;
+// Application settings.
+const VIEW_MODE = VIEW_TYPES.SIDE_BY_SIDE;
+const TOKEN = Cesium.Ion.defaultAccessToken;
+const ASSET_ID = CAIRO_ASSET_ID;
 
-const viewer = new Cesium.Viewer('cesiumContainer');
-const tileMap = {}; // Map the contentUri -> tile so we can unload/set visibility based on loaders.gl's tile events.
+if (VIEW_MODE === VIEW_TYPES.SINGLE) {
+  // Just use the Loaders.gl traversal
+  const viewer = new Cesium.Viewer('loadersViewer');
 
-loadTileset({
-  ionAssetId: MALALISON_ISLAND_ASSET_ID,
-  ionAccessToken: malalisonToken
-  // ionAccessToken: Cesium.Ion.defaultAccessToken
-});
+  document.querySelector('#cesiumViewer').style.display = 'none';
 
-async function loadTileset({tilesetUrl, ionAssetId, ionAccessToken}) {
-  let fetchOptions = null;
-  if (ionAssetId && ionAccessToken) {
-    const {url, headers} = await _getIonTilesetMetadata(ionAccessToken, ionAssetId);
-    tilesetUrl = url;
-    fetchOptions = {headers};
-  }
+  loadTileset({
+    ionAssetId: ASSET_ID,
+    ionAccessToken: TOKEN,
+    viewerInstance: viewer
+  });
+} else if (VIEW_MODE === VIEW_TYPES.SIDE_BY_SIDE) {
+  // Set the viewer on the left to be using LoadersGL loading & traversal,
+  // and the right viewer using CesiumJS's built in loading & traversal.
 
-  const response = await fetch(tilesetUrl, fetchOptions);
-  const tilesetJson = await response.json();
+  const loadersViewer = new Cesium.Viewer('loadersViewer');
 
-  const tileset3d = new Tileset3D(tilesetJson, tilesetUrl, {
-    onTileLoad: tileHeader => loadTile(tileHeader.uri, tileHeader),
-    onTileUnload: tileHeader => unloadTile(tileHeader.contentUri),
-    onTileLoadFailed: tileHeader => console.error('LoadFailed', tileHeader.uri), // eslint-disable-line
-    fetchOptions,
-    throttleRequests: true
+  loadTileset({
+    ionAssetId: ASSET_ID,
+    ionAccessToken: TOKEN,
+    viewerInstance: loadersViewer
   });
 
-  centerTileset(tileset3d);
-
-  viewer.scene.preRender.addEventListener(scene => {
-    const frameState = convertCesiumFrameState(scene.frameState, scene.canvas.height);
-    tileset3d.update(frameState);
-  });
-}
-
-function centerTileset(tileset) {
-  viewer.camera.flyTo({
-    destination: new Cesium.Cartesian3(...tileset.cartesianCenter),
-    duration: 3
-  });
-}
-
-function loadTile(uri, tileHeader) {
-  const type = uri.replace(/\?[\w\W]+/, '').slice(-4); // Make sure to remove query parameters.
-
-  switch (type) {
-    case 'pnts':
-      loadPointTile(uri, tileHeader).then(renderTilePrimitive);
-      break;
-    case 'b3dm':
-      loadBatchedModelTile(uri, tileHeader).then(renderTilePrimitive);
-      break;
-    default:
-      console.log(`${type} is not implemented.`); // eslint-disable-line
-  }
-}
-
-// TODO, hook this up to Tileset3D's tile visible event when that's ready.
-// function setTileVisible(contentUri, visibility) {
-//   tileMap[contentUri].show = visibility;
-// }
-
-function unloadTile(contentUri) {
-  viewer.scene.primitives.remove(tileMap[contentUri]);
-  delete tileMap[contentUri];
-}
-
-function renderTilePrimitive({primitive, tileHeader}) {
-  tileMap[tileHeader.contentUri] = primitive;
-  viewer.scene.primitives.add(primitive);
-}
-
-function convertCesiumFrameState(frameState, height) {
-  let cameraPosition = frameState.camera.position;
-  cameraPosition = new Vector3([cameraPosition.x, cameraPosition.y, cameraPosition.z]);
-
-  let cameraDirection = frameState.camera.direction;
-  cameraDirection = new Vector3([cameraDirection.x, cameraDirection.y, cameraDirection.z]);
-
-  let cameraUp = frameState.camera.up;
-  cameraUp = new Vector3([cameraUp.x, cameraUp.y, cameraUp.z]);
-
-  const planes = frameState.cullingVolume.planes.map(
-    plane => new Plane([plane.x, plane.y, plane.z], plane.w)
+  const cesiumViewer = new Cesium.Viewer('cesiumViewer');
+  cesiumViewer.scene.primitives.add(
+    new Cesium.Cesium3DTileset({
+      url: Cesium.IonResource.fromAssetId(ASSET_ID, {accessToken: TOKEN})
+    })
   );
 
-  return {
-    camera: {
-      position: cameraPosition,
-      direction: cameraDirection,
-      up: cameraUp
-    },
-    height,
-    // TODO update when math.gl published
-    cullingVolume: {planes},
-    frameNumber: frameState.frameNumber, // TODO: This can be the same between updates, what number is unique for between updates?
-    sseDenominator: frameState.camera.frustum.sseDenominator
-  };
+  // Sync the two views
+  loadersViewer.camera.percentageChanged = 0.01;
+  loadersViewer.camera.changed.addEventListener(() =>
+    syncCameras(loadersViewer.camera, cesiumViewer.camera)
+  );
+
+  cesiumViewer.camera.percentageChanged = 0.01;
+  cesiumViewer.camera.changed.addEventListener(() =>
+    syncCameras(cesiumViewer.camera, loadersViewer.camera)
+  );
+}
+
+function syncCameras(sourceCamera, sinkCamera) {
+  // This copies sourceCamera's state onto sinkCamera's.
+  sinkCamera.setView({
+    destination: sourceCamera.position,
+    orientation: {
+      heading: sourceCamera.heading,
+      pitch: sourceCamera.pitch,
+      roll: sourceCamera.roll
+    }
+  });
 }

--- a/examples/cesium/3d-tiles/index.html
+++ b/examples/cesium/3d-tiles/index.html
@@ -8,6 +8,12 @@
       rel="stylesheet"
     />
   </head>
+  <style>
+    html, body {
+      margin:0px;
+      height:100%;
+    }
+  </style>
   <body>
     <div id="cesiumContainer" style="width: 100%; height:100%"></div>
     <script type="module">

--- a/examples/cesium/3d-tiles/index.html
+++ b/examples/cesium/3d-tiles/index.html
@@ -13,9 +13,25 @@
       margin:0px;
       height:100%;
     }
+    #cesiumContainer {
+      display: flex;
+      width: 100%;
+      height: 100%;
+    }
+    #loadersViewer {
+      display: inline-block;
+      width: 100%;
+    }
+    #cesiumViewer {
+      display: inline-block;
+      width: 100%;
+    }
   </style>
   <body>
-    <div id="cesiumContainer" style="width: 100%; height:100%"></div>
+    <div id="cesiumContainer">
+      <div id="loadersViewer"></div>
+      <div id="cesiumViewer"></div>
+    </div>
     <script type="module">
       import './bundle.js';
     </script>

--- a/examples/cesium/3d-tiles/tile-parsers.js
+++ b/examples/cesium/3d-tiles/tile-parsers.js
@@ -1,0 +1,87 @@
+import {load} from '@loaders.gl/core';
+import {Tile3DLoader} from '@loaders.gl/3d-tiles';
+
+/* global Cesium */
+const Axis = Cesium.Axis;
+const Cartesian3 = Cesium.Cartesian3;
+const defined = Cesium.defined;
+const TileOrientedBoundingBox = Cesium.TileOrientedBoundingBox;
+const Matrix3 = Cesium.Matrix3;
+const Matrix4 = Cesium.Matrix4;
+const Model = Cesium.Model;
+const Resource = Cesium.Resource;
+const PointCloud = Cesium.PointCloud;
+const Pass = Cesium.Pass;
+
+function getBoundingSphere(tileHeader) {
+  const center = tileHeader.boundingVolume.center;
+  const halfAxes = tileHeader.boundingVolume.halfAxes;
+
+  const boundingVolume = new TileOrientedBoundingBox(
+    new Cartesian3(center.x, center.y, center.z),
+    Matrix3.fromColumnMajorArray(halfAxes)
+  );
+
+  return boundingVolume._boundingSphere;
+}
+
+function getTransform(tileHeader) {
+  return Matrix4.fromColumnMajorArray(tileHeader.computedTransform);
+}
+
+export function loadPointTile(uri, tileHeader) {
+  const boundingSphere = getBoundingSphere(tileHeader);
+  const computedTransform = getTransform(tileHeader);
+
+  return Resource.fetchArrayBuffer(uri).then(function(arrayBuffer) {
+    const pointCloud = new PointCloud({
+      arrayBuffer,
+      byteOffset: 0,
+      cull: false,
+      opaquePass: Pass.CESIUM_3D_TILE,
+      vertexShaderLoaded: vs => vs,
+      fragmentShaderLoaded: fs => `uniform vec4 czm_pickColor;\n${fs}`,
+      uniformMapLoaded: uniformMap => uniformMap,
+      batchTableLoaded: (batchLength, batchTableJson, batchTableBinary) => {},
+      pickIdLoaded: () => 'czm_pickColor'
+    });
+
+    pointCloud.boundingSphere = boundingSphere;
+    pointCloud.modelMatrix = computedTransform;
+
+    return {
+      primitive: pointCloud,
+      tileHeader
+    };
+  });
+}
+
+export async function loadBatchedModelTile(uri, tileHeader) {
+  const computedTransform = getTransform(tileHeader);
+
+  const content = await load(uri, Tile3DLoader, {
+    '3d-tiles': {
+      loadGLTF: false
+    }
+  });
+
+  if (defined(content.rtcCenter)) {
+    const rtcCenterTransform = Matrix4.fromTranslation(Cartesian3.fromArray(content.rtcCenter));
+    Matrix4.multiply(computedTransform, rtcCenterTransform, computedTransform);
+  }
+
+  const model = new Model({
+    gltf: content.gltfArrayBuffer,
+    cull: false,
+    releaseGltfJson: true,
+    opaquePass: Pass.CESIUM_3D_TILE,
+    modelMatrix: computedTransform,
+    upAxis: Axis.Y,
+    forwardAxis: Axis.X
+  });
+
+  return {
+    primitive: model,
+    tileHeader
+  };
+}

--- a/examples/cesium/3d-tiles/tileset-loader.js
+++ b/examples/cesium/3d-tiles/tileset-loader.js
@@ -1,0 +1,108 @@
+/* global Cesium, fetch */
+
+import {Vector3} from 'math.gl';
+import {registerLoaders, setLoaderOptions} from '@loaders.gl/core';
+import {DracoLoader} from '@loaders.gl/draco';
+import {Tileset3D, _getIonTilesetMetadata} from '@loaders.gl/3d-tiles';
+import {Plane} from '@math.gl/culling';
+import {loadBatchedModelTile, loadPointTile} from './tile-parsers';
+
+const tileMap = {}; // Map the contentUri -> tile so we can unload/set visibility based on loaders.gl's tile events.
+let viewer;
+
+// set up loaders
+registerLoaders([DracoLoader]);
+setLoaderOptions({worker: false});
+
+export async function loadTileset({tilesetUrl, ionAssetId, ionAccessToken, viewerInstance}) {
+  let fetchOptions = null;
+  viewer = viewerInstance;
+  if (ionAssetId && ionAccessToken) {
+    const {url, headers} = await _getIonTilesetMetadata(ionAccessToken, ionAssetId);
+    tilesetUrl = url;
+    fetchOptions = {headers};
+  }
+
+  const response = await fetch(tilesetUrl, fetchOptions);
+  const tilesetJson = await response.json();
+
+  const tileset3d = new Tileset3D(tilesetJson, tilesetUrl, {
+    onTileLoad: tileHeader => loadTile(tileHeader.uri, tileHeader),
+    onTileUnload: tileHeader => unloadTile(tileHeader.contentUri),
+    onTileLoadFailed: tileHeader => console.error('LoadFailed', tileHeader.uri), // eslint-disable-line
+    fetchOptions,
+    throttleRequests: true
+  });
+
+  centerTileset(tileset3d);
+
+  viewer.scene.preRender.addEventListener(scene => {
+    const frameState = convertCesiumFrameState(scene.frameState, scene.canvas.height);
+    tileset3d.update(frameState);
+  });
+}
+
+function centerTileset(tileset) {
+  viewer.camera.flyTo({
+    destination: new Cesium.Cartesian3(...tileset.cartesianCenter),
+    duration: 3
+  });
+}
+
+function loadTile(uri, tileHeader) {
+  const type = uri.replace(/\?[\w\W]+/, '').slice(-4); // Make sure to remove query parameters.
+
+  switch (type) {
+    case 'pnts':
+      loadPointTile(uri, tileHeader).then(renderTilePrimitive);
+      break;
+    case 'b3dm':
+      loadBatchedModelTile(uri, tileHeader).then(renderTilePrimitive);
+      break;
+    default:
+      console.log(`${type} is not implemented.`); // eslint-disable-line
+  }
+}
+
+// TODO, hook this up to Tileset3D's tile visible event when that's ready.
+// function setTileVisible(contentUri, visibility) {
+//   tileMap[contentUri].show = visibility;
+// }
+
+function unloadTile(contentUri) {
+  viewer.scene.primitives.remove(tileMap[contentUri]);
+  delete tileMap[contentUri];
+}
+
+function renderTilePrimitive({primitive, tileHeader}) {
+  tileMap[tileHeader.contentUri] = primitive;
+  viewer.scene.primitives.add(primitive);
+}
+
+function convertCesiumFrameState(frameState, height) {
+  let cameraPosition = frameState.camera.position;
+  cameraPosition = new Vector3([cameraPosition.x, cameraPosition.y, cameraPosition.z]);
+
+  let cameraDirection = frameState.camera.direction;
+  cameraDirection = new Vector3([cameraDirection.x, cameraDirection.y, cameraDirection.z]);
+
+  let cameraUp = frameState.camera.up;
+  cameraUp = new Vector3([cameraUp.x, cameraUp.y, cameraUp.z]);
+
+  const planes = frameState.cullingVolume.planes.map(
+    plane => new Plane([plane.x, plane.y, plane.z], plane.w)
+  );
+
+  return {
+    camera: {
+      position: cameraPosition,
+      direction: cameraDirection,
+      up: cameraUp
+    },
+    height,
+    // TODO update when math.gl published
+    cullingVolume: {planes},
+    frameNumber: frameState.frameNumber, // TODO: This can be the same between updates, what number is unique for between updates?
+    sseDenominator: frameState.camera.frustum.sseDenominator
+  };
+}


### PR DESCRIPTION
This PR extends the CesiumJS example to support loading of b3dm tiles. It also adds a "side by side" mode that makes it easier to compare what a tileset looks like loaded with CesiumJS's built-in loading & traversal vs Loaders.gl handling all the loading and traversal, and just passing the model (or point cloud) and its location for CesiumJS to render.

Some notes:

* I added in a `setTileVisible` in `tileset-loader.js` that can be the callback for when Loaders.gl emits an event when any given tile's visibility changes
* I noticed with B3dm tilesets, it seems as though 
* I also noticed the `onTileLoad`, fires both for the b3dm/pnts content, but also for the `json` in case of a tileset that links to another tileset. Is it on me as the user of loaders.gl to run `new Tileset3D()` on that tile content, or is that already handled? Right now I'm just ignoring those tiles.
  * This may be related to the above, but I noticed that the b3dm tilesets I'm loading don't seem to unload the parent tiles. So you can see the low res root tile poking through the high res tiles that load in.
* It was really convenient to have the `load` function from `'@loaders.gl/core'`. I was fetching the tile content directly for the point cloud, but the b3dm one needs to be decoded to get the RTC and the glTF buffer, so it's great that Loaders.gl gives me exactly what I need and I don't have to worry about that.