### PR TITLE
Hide tiles that are not visible this frame in Cesium example

### DIFF
--- a/examples/cesium/3d-tiles/app.js
+++ b/examples/cesium/3d-tiles/app.js
@@ -16,8 +16,8 @@ const VIEW_TYPES = {SINGLE: 0, SIDE_BY_SIDE: 1};
 
 // Application settings.
 const VIEW_MODE = VIEW_TYPES.SIDE_BY_SIDE;
-const TOKEN = Cesium.Ion.defaultAccessToken;
-const ASSET_ID = CAIRO_ASSET_ID;
+const TOKEN = malalisonToken;
+const ASSET_ID = MALALISON_ISLAND_ASSET_ID;
 
 if (VIEW_MODE === VIEW_TYPES.SINGLE) {
   // Just use the Loaders.gl traversal

--- a/examples/cesium/3d-tiles/tileset-loader.js
+++ b/examples/cesium/3d-tiles/tileset-loader.js
@@ -39,6 +39,16 @@ export async function loadTileset({tilesetUrl, ionAssetId, ionAccessToken, viewe
   viewer.scene.preRender.addEventListener(scene => {
     const frameState = convertCesiumFrameState(scene.frameState, scene.canvas.height);
     tileset3d.update(frameState);
+
+    for (const tile of Object.values(tileMap)) {
+      tile.show = false;
+    }
+
+    for (const tile of tileset3d.selectedTiles) {
+      if (tile.contentAvailable && tileMap[tile.contentUri]) {
+        tileMap[tile.contentUri].show = true;
+      }
+    }
   });
 }
 
@@ -63,11 +73,6 @@ function loadTile(uri, tileHeader) {
       console.log(`${type} is not implemented.`); // eslint-disable-line
   }
 }
-
-// TODO, hook this up to Tileset3D's tile visible event when that's ready.
-// function setTileVisible(contentUri, visibility) {
-//   tileMap[contentUri].show = visibility;
-// }
 
 function unloadTile(contentUri) {
   viewer.scene.primitives.remove(tileMap[contentUri]);


### PR DESCRIPTION
@ibgreen as per our discussion on https://github.com/uber-web/loaders.gl/issues/481#issuecomment-541984920, I updated the example to only show tiles that are visible this frame. But `tileset3d.update` doesn't seem to return anything. The [docs say](https://loaders.gl/modules/3d-tiles/docs) to use `tileset3d.traverse()` but I think that was renamed to update? 

The good news is that I am able to reproduce the tiles disappearing issue we were seeing from before when testing in Deck.gl. There seem to be 2 issues which may be related:

* If you try the Cairo tileset, you'll see it refines to the children, but then as you zoom closer, it seems to traverse backwards, going back to the root tile, before tiles start to disappear.
* In the Malalison island tileset, the issue is not as bad, but you can sometimes see tiles disappearing around the edges (although that may just be culling too early? I wasn't able to get a tile in dead center of the screen to disappear in the way I could with the Cairo tileset, so the issue may be limited to tilesets with external tilesets).