### PR TITLE
fix: change ply-loader color array type to Float32Array

### DIFF
--- a/modules/ply/src/lib/normalize-ply.js
+++ b/modules/ply/src/lib/normalize-ply.js
@@ -35,6 +35,7 @@ function normalizeAttributes(attributes) {
   }
 
   if (attributes.colors.length > 0) {
+    // Uint8Array => Float32Array
     accessors.COLOR_0 = {value: new Float32Array(attributes.colors), size: 3};
   }
 

--- a/modules/ply/src/lib/normalize-ply.js
+++ b/modules/ply/src/lib/normalize-ply.js
@@ -35,7 +35,7 @@ function normalizeAttributes(attributes) {
   }
 
   if (attributes.colors.length > 0) {
-    accessors.COLOR_0 = {value: new Uint8Array(attributes.colors), size: 3};
+    accessors.COLOR_0 = {value: new Float32Array(attributes.colors), size: 3};
   }
 
   return accessors;


### PR DESCRIPTION
before change color array type
my program not work as my expect
![image](https://user-images.githubusercontent.com/18349295/69114668-fcd46d00-0ac0-11ea-8ab2-b73497a2f3f7.png)

i just change the Uint8Array to Float32Array, it works well!
![image](https://user-images.githubusercontent.com/18349295/69114607-e4645280-0ac0-11ea-863c-48398a8d2aba.png)
