### PR TITLE
PLYLoader: Fix handling of color values

### DIFF
--- a/examples/deck.gl/pointcloud/app.js
+++ b/examples/deck.gl/pointcloud/app.js
@@ -10,10 +10,8 @@ import {LASLoader} from '@loaders.gl/las';
 import {PLYLoader} from '@loaders.gl/ply';
 import {PCDLoader} from '@loaders.gl/pcd';
 import {OBJLoader} from '@loaders.gl/obj';
-// TODO fix LasWorkerLoader
-// import {LASWorkerLoader} from '@loaders.gl/las/worker-loader';
 
-import {load, registerLoaders} from '@loaders.gl/core';
+import {load, registerLoaders, setLoaderOptions} from '@loaders.gl/core';
 
 import ControlPanel from './components/control-panel';
 // import fileDrop from './components/file-drop';
@@ -22,6 +20,8 @@ import FILE_INDEX from './file-index';
 
 // Additional format support can be added here, see
 registerLoaders([DracoLoader, LASLoader, PLYLoader, PCDLoader, OBJLoader]);
+// TODO fix WorkerLoader
+setLoaderOptions({worker: false});
 
 const INITIAL_VIEW_STATE = {
   target: [0, 0, 0],
@@ -109,7 +109,11 @@ export default class App extends PureComponent {
     this.setState(
       {
         loadTimeMs: Date.now() - this._loadStartMs,
-        pointsCount: header.vertexCount,
+        // TODO - Some popular "point cloud" formats (PLY) can also generate indexed meshes
+        // in which case the vertex count is not correct for display as points
+        // Proposal: Consider adding a `mesh.points` or `mesh.pointcloud` option to mesh loaders
+        // in which case the loader throws away indices and just return the vertices?
+        pointsCount: attributes.POSITION.value.length / 3, // header.vertexCount,
         points: attributes.POSITION.value,
         viewState
       },

--- a/modules/ply/src/lib/normalize-ply.js
+++ b/modules/ply/src/lib/normalize-ply.js
@@ -35,7 +35,8 @@ function normalizeAttributes(attributes) {
   }
 
   if (attributes.colors.length > 0) {
-    accessors.COLOR_0 = {value: new Uint8Array(attributes.colors), size: 3};
+    // TODO - normalized shoud be based on `uchar` flag in source data?
+    accessors.COLOR_0 = {value: new Uint8Array(attributes.colors), size: 3, normalized: true};
   }
 
   return accessors;

--- a/modules/ply/src/lib/parse-ply.js
+++ b/modules/ply/src/lib/parse-ply.js
@@ -244,7 +244,7 @@ function handleElement(buffer, elementName, element) {
     }
 
     if ('red' in element && 'green' in element && 'blue' in element) {
-      buffer.colors.push(element.red / 255.0, element.green / 255.0, element.blue / 255.0);
+      buffer.colors.push(element.red, element.green, element.blue);
     }
   } else if (elementName === 'face') {
     const vertexIndices = element.vertex_indices || element.vertex_index; // issue #9338


### PR DESCRIPTION
@zt123123 - Re #528 #533 The "right" fix should be to stop dividing with 255, and set the `normalized: true` flag on the generated attribute.

Converting to `Float32Array` will make the colors consume 4x as much memory.