### PR TITLE
improve distanceToTile calculation

### DIFF
--- a/modules/3d-tiles/src/lib/tileset/tile-3d-header.js
+++ b/modules/3d-tiles/src/lib/tileset/tile-3d-header.js
@@ -473,9 +473,7 @@ export default class Tile3DHeader {
   // @returns {Number} The distance, in meters, or zero if the camera is inside the bounding volume.
   distanceToTile(frameState) {
     const boundingVolume = this._boundingVolume;
-    return Math.sqrt(
-      Math.max(boundingVolume.distanceSquaredTo(frameState.camera.position), 0.0000001)
-    );
+    return Math.sqrt(Math.max(boundingVolume.distanceSquaredTo(frameState.camera.position), 0));
   }
 
   // Computes the tile's camera-space z-depth.

--- a/modules/3d-tiles/src/lib/tileset/tile-3d-header.js
+++ b/modules/3d-tiles/src/lib/tileset/tile-3d-header.js
@@ -473,7 +473,9 @@ export default class Tile3DHeader {
   // @returns {Number} The distance, in meters, or zero if the camera is inside the bounding volume.
   distanceToTile(frameState) {
     const boundingVolume = this._boundingVolume;
-    return Math.sqrt(boundingVolume.distanceSquaredTo(frameState.camera.position));
+    return Math.sqrt(
+      Math.max(boundingVolume.distanceSquaredTo(frameState.camera.position), 0.0000001)
+    );
   }
 
   // Computes the tile's camera-space z-depth.


### PR DESCRIPTION
For #524 

The root tile covers the whole area in high zoom because of invalid space error.