### PR TITLE
Fix `load` when using auto loader detection

### DIFF
--- a/modules/core/src/lib/parse.js
+++ b/modules/core/src/lib/parse.js
@@ -10,7 +10,7 @@ import {selectLoader} from './select-loader';
 export async function parse(data, loaders, options, context) {
   // Signature: parse(data, options, context | url)
   // Uses registered loaders
-  if (!Array.isArray(loaders) && !isLoaderObject(loaders)) {
+  if (loaders && !Array.isArray(loaders) && !isLoaderObject(loaders)) {
     context = options;
     options = loaders;
     loaders = null;

--- a/modules/core/test/lib/load.spec.js
+++ b/modules/core/test/lib/load.spec.js
@@ -22,13 +22,15 @@ test('load#auto detect loader', t => {
   const TEST_LOADER = {
     name: 'JSON',
     extensions: ['json'],
-    parse: async arrayBuffer => {
+    parse: async (arrayBuffer, options, context) => {
       t.ok(arrayBuffer instanceof ArrayBuffer, 'Got ArrayBuffer');
+      t.deepEquals(options.JSON, {option: true}, 'Option is passed through');
+      t.ok(context.parse, 'context is populated');
       t.end();
     }
   };
   registerLoaders(TEST_LOADER);
-  load('package.json');
+  load('package.json', {JSON: {option: true}});
 });
 
 test('load#Blob (text)', async t => {


### PR DESCRIPTION
`parse` is confused about incoming arguments when `loaders` is `null` (happens when calling `load(url, options)`).

Add a unit test.