### PR TITLE
Make traversal synchronous and fix the tile-3d-layer example flashing issue

### DIFF
--- a/examples/deck.gl/3d-tiles/3d-tile-layer/tile-3d-layer.js
+++ b/examples/deck.gl/3d-tiles/3d-tile-layer/tile-3d-layer.js
@@ -89,7 +89,7 @@ export default class Tile3DLayer extends CompositeLayer {
     return await this._loadTileset(url, {headers}, ionMetadata);
   }
 
-  async _updateTileset(tileset3d) {
+  _updateTileset(tileset3d) {
     const {timeline, viewport} = this.context;
     if (!timeline || !viewport || !tileset3d) {
       return;
@@ -97,7 +97,7 @@ export default class Tile3DLayer extends CompositeLayer {
 
     // use Date.now() as frame identifier for now and later used to filter layers for rendering
     const frameState = getFrameState(viewport, Date.now());
-    await tileset3d.update(frameState);
+    tileset3d.update(frameState);
     this._updateLayerMap(frameState.frameNumber);
   }
 
@@ -110,9 +110,6 @@ export default class Tile3DLayer extends CompositeLayer {
     const tilesWithoutLayer = selectedTiles.filter(tile => !layerMap[tile.fullUri]);
 
     for (const tile of tilesWithoutLayer) {
-      // TODO - why do we call this here? Being "selected" should automatically add it to cache?
-      tileset3d.addTileToCache(tile);
-
       layerMap[tile.fullUri] = {
         layer: this._create3DTileLayer(tile),
         tile

--- a/examples/deck.gl/3d-tiles/app.js
+++ b/examples/deck.gl/3d-tiles/app.js
@@ -12,7 +12,7 @@ import {StatsWidget} from '@probe.gl/stats-widget';
 
 // To manage dependencies and bundle size, the app must decide which supporting loaders to bring in
 import {registerLoaders} from '@loaders.gl/core';
-import {DracoLoader} from '@loaders.gl/draco';
+import {DracoWorkerLoader} from '@loaders.gl/draco';
 import {GLTFLoader} from '@loaders.gl/gltf';
 
 import ControlPanel from './components/control-panel';
@@ -21,7 +21,7 @@ import {loadExampleIndex, INITIAL_EXAMPLE_CATEGORY, INITIAL_EXAMPLE_NAME} from '
 import {INITIAL_MAP_STYLE} from './constants';
 
 // enable DracoWorkerLoader when fixed
-registerLoaders([GLTFLoader, DracoLoader]);
+registerLoaders([GLTFLoader, DracoWorkerLoader]);
 
 // Set your mapbox token here
 const MAPBOX_TOKEN = process.env.MapboxAccessToken; // eslint-disable-line
@@ -241,7 +241,7 @@ export default class App extends PureComponent {
       data: tilesetUrl,
       _ionAssetId: ionAssetId,
       _ionAccessToken: ionAccessToken,
-      pointSize: 1,
+      pointSize: 2,
       getPointColor: [115, 112, 202],
       onTilesetLoad: this._onTilesetLoad,
       onTileLoad: this._onTilesetChange,

--- a/modules/i3s/src/lib/tileset/i3s-tile-manager.js
+++ b/modules/i3s/src/lib/tileset/i3s-tile-manager.js
@@ -1,0 +1,37 @@
+const STATUS = {
+  REQUESTED: 'REQUESTED',
+  COMPLETED: 'COMPLETED',
+  ERROR: 'ERROR'
+};
+
+// A helper class to manage tile metadata fetching
+export default class I3STileManager {
+  constructor() {
+    this._statusMap = {};
+  }
+
+  add(request, key, callback, options) {
+    if (!this._statusMap[key]) {
+      this._statusMap[key] = {request, callback, key, options, status: STATUS.REQUESTED};
+      request()
+        .then(data => {
+          this._statusMap[key].status = STATUS.COMPLETED;
+          this._statusMap[key].callback(data, options);
+        })
+        .catch(error => {
+          this._statusMap[key].status = STATUS.ERROR;
+          callback(error);
+        });
+    }
+  }
+
+  update(key, options) {
+    if (this._statusMap[key]) {
+      this._statusMap[key].options = options;
+    }
+  }
+
+  find(key) {
+    return this._statusMap[key];
+  }
+}


### PR DESCRIPTION
Problem:

When the traversal is asynchronous, different update and traversal cycles will update the same traversal stack, and messed up with the traversal results.

Solution:
In this PR, change the asynchronous traversal back to synchronous.

For i3s tile traversal, it may need fetching tile metadata during traversal, so provide a callback to the fetch call which will resume the traversal from tile after fetched.



 