### PR TITLE
loader-utils: Move resolvePath from core to loader-utils

### DIFF
--- a/modules/core/docs/api-reference/set-path-prefix.md
+++ b/modules/core/docs/api-reference/set-path-prefix.md
@@ -4,10 +4,6 @@
 
 Applies aliases and path prefix, in that order. Returns an updated path.
 
-### addAliases(aliases : Object)
-
-Sets a map of aliases (file name substitutions).
-
 ### setPathPrefix(prefix : String)
 
 This sets a path prefix that is automatically prepended to relative path names provided to load functions.

--- a/modules/core/src/index.js
+++ b/modules/core/src/index.js
@@ -4,8 +4,6 @@ import * as path from './lib/path/path';
 export {path};
 
 // FILE READING AND WRITING
-export {setPathPrefix, getPathPrefix, resolvePath} from '@loaders.gl/loader-utils';
-
 export {fetchFile} from './lib/fetch/fetch-file';
 export {readFileSync} from './lib/fetch/read-file';
 export {writeFile, writeFileSync} from './lib/fetch/write-file';
@@ -55,9 +53,10 @@ export {
   numberedLineAsyncIterator
 } from './javascript-utils/async-iterator-utils';
 
-// CORE UTILS
+// CORE UTILS SHARED WITH LOADERS (RE-EXPORTED FROM LOADER-UTILS)
 export {isBrowser, isWorker, self, window, global, document} from '@loaders.gl/loader-utils';
 export {assert} from '@loaders.gl/loader-utils';
+export {setPathPrefix, getPathPrefix, resolvePath} from '@loaders.gl/loader-utils';
 
 // EXPERIMENTAL
 export {selectLoader as _selectLoader} from './lib/select-loader';
@@ -67,8 +66,6 @@ export {default as _WorkerFarm} from './worker-utils/worker-farm';
 export {default as _WorkerPool} from './worker-utils/worker-pool';
 
 export {default as _fetchProgress} from './lib/progress/fetch-progress';
-
-// export {writeFile as _writeFile} from './core-addons/write-file-browser';
 
 // FOR TESTING
 export {_unregisterLoaders} from './lib/register-loaders';

--- a/modules/core/src/index.js
+++ b/modules/core/src/index.js
@@ -4,7 +4,8 @@ import * as path from './lib/path/path';
 export {path};
 
 // FILE READING AND WRITING
-export {setPathPrefix, getPathPrefix, resolvePath} from './lib/fetch/file-aliases.js';
+export {setPathPrefix, getPathPrefix, resolvePath} from '@loaders.gl/loader-utils';
+
 export {fetchFile} from './lib/fetch/fetch-file';
 export {readFileSync} from './lib/fetch/read-file';
 export {writeFile, writeFileSync} from './lib/fetch/write-file';
@@ -70,5 +71,4 @@ export {default as _fetchProgress} from './lib/progress/fetch-progress';
 // export {writeFile as _writeFile} from './core-addons/write-file-browser';
 
 // FOR TESTING
-export {addAliases as _addAliases} from './lib/fetch/file-aliases.js';
 export {_unregisterLoaders} from './lib/register-loaders';

--- a/modules/core/src/lib/fetch/fetch-file.js
+++ b/modules/core/src/lib/fetch/fetch-file.js
@@ -1,6 +1,6 @@
 /* global fetch */
+import {resolvePath} from '@loaders.gl/loader-utils';
 import {isFileReadable} from '../../javascript-utils/is-type';
-import {resolvePath} from './file-aliases';
 import fetchFileReadable from './fetch-file.browser';
 
 // As fetch but respects pathPrefix and file aliases

--- a/modules/core/src/lib/fetch/read-file.js
+++ b/modules/core/src/lib/fetch/read-file.js
@@ -1,6 +1,5 @@
-import {isBrowser} from '@loaders.gl/loader-utils';
+import {isBrowser, resolvePath} from '@loaders.gl/loader-utils';
 import * as node from '../../node/read-file-sync.node';
-import {resolvePath} from './file-aliases';
 import {readFileSyncBrowser} from './read-file.browser';
 
 // In a few cases (data URIs, node.js) "files" can be read synchronously

--- a/modules/core/src/lib/fetch/write-file.js
+++ b/modules/core/src/lib/fetch/write-file.js
@@ -1,6 +1,5 @@
-import {isBrowser, assert} from '@loaders.gl/loader-utils';
+import {isBrowser, assert, resolvePath} from '@loaders.gl/loader-utils';
 import * as node from '../../node/write-file.node';
-import {resolvePath} from './file-aliases';
 
 export function writeFile(filePath, arrayBufferOrString, options) {
   filePath = resolvePath(filePath);

--- a/modules/core/test/lib/fetch/fetch-error-message.spec.js
+++ b/modules/core/test/lib/fetch/fetch-error-message.spec.js
@@ -1,10 +1,8 @@
 import test from 'tape-promise/tape';
 
 import {_getErrorMessageFromResponseSync, _getErrorMessageFromResponse} from '@loaders.gl/core';
-// NOTE: addAliases is not a public export, already used by test setup
-// import {addAliases} from '@loaders.gl/core';
 
-test('file aliases#imports', t => {
+test('_getErrorMessageFromResponseSync#imports', t => {
   t.ok(
     typeof _getErrorMessageFromResponseSync === 'function',
     '_getErrorMessageFromResponseSync() defined'

--- a/modules/core/test/lib/fetch/index.js
+++ b/modules/core/test/lib/fetch/index.js
@@ -1,4 +1,3 @@
-import './file-aliases.spec';
 import './fetch-error-message.spec';
 import './fetch-file.spec';
 import './fetch-file.browser.spec';

--- a/modules/images/test/lib/texture-loading-api/load-image.spec.js
+++ b/modules/images/test/lib/texture-loading-api/load-image.spec.js
@@ -1,7 +1,7 @@
 import test from 'tape-promise/tape';
 
 import {loadImage, loadImageArray, loadImageCube, isImage} from '@loaders.gl/images';
-import {resolvePath} from '@loaders.gl/core';
+import {resolvePath} from '@loaders.gl/loader-utils';
 
 const LUT_URL = resolvePath('@loaders.gl/images/test/data/ibl/brdfLUT.png');
 const PAPERMILL_URL = resolvePath('@loaders.gl/images/test/data/ibl/papermill');

--- a/modules/loader-utils/src/index.js
+++ b/modules/loader-utils/src/index.js
@@ -40,6 +40,12 @@ export {
 } from './lib/binary-utils/encode-utils';
 export {getFirstCharacters, getMagicString} from './lib/binary-utils/get-first-characters';
 
+// PATH UTILS
+
+export {setPathPrefix, getPathPrefix, resolvePath} from './lib/path-utils/file-aliases';
+// FOR TESTING ONLY, EXPERIMENTAL
+export {addAliases as _addAliases} from './lib/path-utils/file-aliases.js';
+
 // MESH CATEGORY UTILS
 // Note: Should move to category specific module if code size increases
 export {getMeshSize as _getMeshSize} from './categories/mesh/mesh-utils';

--- a/modules/loader-utils/src/lib/path-utils/file-aliases.js
+++ b/modules/loader-utils/src/lib/path-utils/file-aliases.js
@@ -14,7 +14,9 @@ export function getPathPrefix() {
   return pathPrefix;
 }
 
-// Note: addAliases are not exported at the moment, they are only for loaders.gl testing
+// Note: addAliases are an experimental export,
+// they are only for testing of loaders.gl loaders
+// not inteded as a generic aliasing mechanism
 export function addAliases(aliases) {
   Object.assign(fileAliases, aliases);
 }

--- a/modules/loader-utils/test/index.js
+++ b/modules/loader-utils/test/index.js
@@ -4,5 +4,8 @@ import './lib/binary-utils/memory-copy-utils.spec';
 import './lib/library-utils/require-utils.spec';
 import './lib/library-utils/library-utils.spec';
 
+import './lib/path-utils/file-aliases.spec';
+
 import './categories/mesh/mesh-utils.spec';
+
 import './worker-utils/validate-loader-version.spec';

--- a/modules/loader-utils/test/lib/path-utils/file-aliases.spec.js
+++ b/modules/loader-utils/test/lib/path-utils/file-aliases.spec.js
@@ -1,8 +1,9 @@
 import test from 'tape-promise/tape';
 
-import {setPathPrefix, getPathPrefix, resolvePath} from '@loaders.gl/core';
+import {setPathPrefix, getPathPrefix, resolvePath} from '@loaders.gl/loader-utils';
+
 // NOTE: addAliases is not a public export, already used by test setup
-// import {addAliases} from '@loaders.gl/core';
+// import {_addAliases} from '@loaders.gl/loader-utils';
 
 test('file aliases#imports', t => {
   t.ok(typeof setPathPrefix === 'function', 'setPathPrefix() defined');

--- a/modules/polyfills/test/fetch-node/fetch.node.spec.js
+++ b/modules/polyfills/test/fetch-node/fetch.node.spec.js
@@ -1,8 +1,7 @@
 /* global fetch */
 import test from 'tape-promise/tape';
 import '@loaders.gl/polyfills';
-import {isBrowser} from '@loaders.gl/core';
-import {resolvePath} from '@loaders.gl/core/lib/fetch/file-aliases';
+import {isBrowser, resolvePath} from '@loaders.gl/core';
 
 const PLY_CUBE_ATT_URL = resolvePath('@loaders.gl/ply/test/data/cube_att.ply');
 

--- a/test/modules.js
+++ b/test/modules.js
@@ -1,7 +1,7 @@
 // Sets up aliases for file reader
 
 const ALIASES = require('./aliases');
-const {_addAliases} = require('@loaders.gl/core');
+const {_addAliases} = require('@loaders.gl/loader-utils');
 _addAliases(ALIASES);
 
 // Install polyfills (primarily for Node)


### PR DESCRIPTION
To support #541, non-core modules such as images may need to import `resolvePath`.

This PR moves `resolvePath` from core to loader-utils to minimize the size impact on the images module (which currently has no dependencies and could be used stand-alone).

An alternate mechanism would be to make resolvePath available through some global variable, so that it can be used dynamically if core has been imported..

