### PR TITLE
json: Add benchmark (+ fix existing benchmarks)

### DIFF
--- a/modules/core/src/lib/encode.js
+++ b/modules/core/src/lib/encode.js
@@ -1,9 +1,9 @@
-export function encode(data, writer, options, url) {
+export async function encode(data, writer, options, url) {
   if (writer.encode) {
-    return writer.encode(data, options);
+    return await writer.encode(data, options);
   }
   if (writer.encodeSync) {
-    return Promise.resolve(writer.encodeSync(data, options));
+    return writer.encodeSync(data, options);
   }
   // TODO - Use encodeToBatches?
   throw new Error('Writer could not encode data');

--- a/modules/core/src/lib/loader-utils/get-data.js
+++ b/modules/core/src/lib/loader-utils/get-data.js
@@ -59,8 +59,9 @@ export async function getArrayBufferOrStringFromData(data, loader) {
   }
 
   if (isFetchResponse(data)) {
-    await checkFetchResponseStatus(data);
-    return loader.binary ? await data.arrayBuffer() : await data.text();
+    const response = data;
+    await checkFetchResponseStatus(response);
+    return loader.binary ? await response.arrayBuffer() : await response.text();
   }
 
   // if (isIterable(data) || isAsyncIterable(data)) {

--- a/modules/core/src/lib/loader-utils/parse-with-worker.js
+++ b/modules/core/src/lib/loader-utils/parse-with-worker.js
@@ -4,6 +4,8 @@ import WorkerFarm from '../../worker-utils/worker-farm';
 import {getTransferList} from '../../worker-utils/get-transfer-list';
 import {parse} from '../parse';
 
+const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
+
 export function canParseWithWorker(loader, data, options, context) {
   if (!WorkerFarm.isSupported()) {
     return false;
@@ -37,10 +39,12 @@ export default function parseWithWorker(loader, data, options, context) {
   // TODO - decide how to handle logging on workers
   options = JSON.parse(JSON.stringify(options));
 
-  return workerFarm.process(workerSource, `loaders.gl-${workerName}`, {
+  const warning = loader.version !== VERSION ? `(core version ${VERSION})` : '';
+
+  return workerFarm.process(workerSource, `loaders.gl@${loader.version}${warning}:${workerName}`, {
     arraybuffer: toArrayBuffer(data),
     options,
-    source: `loaders.gl@${__VERSION__}`, // Lets worker ignore unrelated messages
+    source: `loaders.gl@${VERSION}`, // Lets worker ignore unrelated messages
     type: 'parse' // For future extension
   });
 }

--- a/modules/core/src/worker-utils/worker-pool.js
+++ b/modules/core/src/worker-utils/worker-pool.js
@@ -85,7 +85,7 @@ export default class WorkerPool {
     // Create fresh worker if we haven't yet created the max amount of worker threads for this worker source
     if (this.count < this.maxConcurrency) {
       this.count++;
-      const name = `${this.name.toLowerCase()}-worker-${this.count}-of-${this.maxConcurrency}`;
+      const name = `${this.name.toLowerCase()}-worker (#${this.count} of ${this.maxConcurrency})`;
       return new WorkerThread({source: this.source, onMessage: this.onMessage, name});
     }
 

--- a/modules/core/test/core.bench.js
+++ b/modules/core/test/core.bench.js
@@ -1,26 +1,29 @@
-const LENGTH = 10000;
+const LENGTH = 1e3;
 const ARRAY = new Array(LENGTH).fill(0);
 
 // TODO - Async benchmarks pending probe.gl update
-// async function *asyncIterator(array) {
-//   for (const element of array) {
-//     yield Promise.resolve(element);
-//   }
-// }
+async function* asyncIterator(array) {
+  for (const element of array) {
+    yield Promise.resolve(element);
+  }
+}
 
 export default function coreBench(bench) {
-  return bench.group('Core Module - Async Iteration').add('Normal Iteration 10K', () => {
+  bench.group('Core Module - Async Iteration');
+
+  bench.add('Sync Iteration over 1000 elements', () => {
     let sum = 0;
     for (const element of ARRAY) {
       sum += element;
     }
     return sum;
   });
-  // .addAsync('Async Iteration 10K', async () => {
-  //   let sum = 0;
-  //   for await (const element of asyncIterator(ARRAY)) {
-  //     sum += element;
-  //   }
-  //   return sum;
-  // });
+
+  bench.addAsync('Async Iteration over 1000 elements', async () => {
+    let sum = 0;
+    for await (const element of asyncIterator(ARRAY)) {
+      sum += element;
+    }
+    return sum;
+  });
 }

--- a/modules/csv/package.json
+++ b/modules/csv/package.json
@@ -32,5 +32,8 @@
   "dependencies": {
     "@loaders.gl/core": "2.0.0-beta.8",
     "@loaders.gl/tables": "2.0.0-beta.8"
+  },
+  "devDependencies": {
+    "d3-dsv": "^1.2.0"
   }
 }

--- a/modules/csv/test/csv.bench.js
+++ b/modules/csv/test/csv.bench.js
@@ -3,25 +3,29 @@ import {CSVLoader} from '@loaders.gl/csv';
 
 const SAMPLE_CSV_URL = '@loaders.gl/csv/test/data/sample-very-long.csv';
 
-/*
 // Comparison loader based on D3
 import {csvParseRows} from 'd3-dsv';
 
 const D3CSVLoader = {
-  name: 'CSV',
+  name: 'D3 CSV',
   extensions: ['csv'],
   testText: null,
-  parseTextSync: csvParseRows
+  text: true,
+  parseTextSync: text => csvParseRows(text)
 };
-*/
 
 export default async function csvBench(bench) {
-  const sample = await fetchFile(SAMPLE_CSV_URL);
+  const response = await fetchFile(SAMPLE_CSV_URL);
+  const sample = await response.text();
 
   bench = bench.group('CSV Decode');
 
-  bench = bench.addAsync('CSVLoader#decode', async () => {
-    parse(sample, CSVLoader);
+  bench = bench.addAsync('CSVLoader#parse', async () => {
+    return await parse(sample, CSVLoader);
+  });
+
+  bench = bench.addAsync('d3-dsv#parse', async () => {
+    return await parse(sample, D3CSVLoader);
   });
 
   return bench;

--- a/modules/draco/src/draco-writer.js
+++ b/modules/draco/src/draco-writer.js
@@ -6,22 +6,28 @@ export default {
   extensions: ['drc'],
   encode,
   options: {
-    pointcloud: false // Set to true if pointcloud (mode: 0, no indices)
-    // Draco Compression Parameters
-    // method: 'MESH_EDGEBREAKER_ENCODING',
-    // speed: [5, 5],
-    // quantization: {
-    //   POSITION: 10
-    // }
+    draco: {
+      pointcloud: false // Set to true if pointcloud (mode: 0, no indices)
+      // Draco Compression Parameters
+      // method: 'MESH_EDGEBREAKER_ENCODING',
+      // speed: [5, 5],
+      // quantization: {
+      //   POSITION: 10
+      // }
+    }
   }
 };
 
 async function encode(data, options) {
+  // DEPRECATED - remove support for options
+  const dracoOptions = (options && options.draco) || options || {};
+
   // Dynamically load draco
-  const {draco} = await loadDracoEncoderModule(options);
+  const {draco} = await loadDracoEncoderModule(options || {});
   const dracoBuilder = new DRACOBuilder(draco);
+
   try {
-    return dracoBuilder.encodeSync(data, options);
+    return dracoBuilder.encodeSync(data, dracoOptions);
   } finally {
     dracoBuilder.destroy();
   }

--- a/modules/draco/test/draco-compression-ratio.spec.js
+++ b/modules/draco/test/draco-compression-ratio.spec.js
@@ -23,7 +23,7 @@ test('DracoWriter#compressRawBuffers', async t => {
 
   // Encode mesh
   // TODO - Replace with draco writer
-  const compressedMesh = await encode({attributes}, DracoWriter, {pointcloud: true});
+  const compressedMesh = await encode({attributes}, DracoWriter, {draco: {pointcloud: true}});
   const meshSize = _getMeshSize(attributes);
   const ratio = meshSize / compressedMesh.byteLength;
   t.comment(`Draco compression ${compressedMesh.byteLength} bytes, ratio ${ratio.toFixed(1)}`);

--- a/modules/draco/test/draco-writer.spec.js
+++ b/modules/draco/test/draco-writer.spec.js
@@ -9,19 +9,23 @@ const TEST_CASES = [
   {
     title: 'Encoding Draco Mesh: SEQUENTIAL',
     options: {
-      method: 'MESH_SEQUENTIAL_ENCODING'
+      draco: {
+        method: 'MESH_SEQUENTIAL_ENCODING'
+      }
     }
   },
   {
     title: 'Encoding Draco Mesh: EDGEBREAKER',
     options: {
-      method: 'MESH_EDGEBREAKER_ENCODING'
+      draco: {
+        method: 'MESH_EDGEBREAKER_ENCODING'
+      }
     }
   },
   {
     title: 'Encoding Draco PointCloud (no indices)',
     options: {
-      pointcloud: true
+      draco: {pointcloud: true}
     }
   }
 ];
@@ -57,7 +61,7 @@ test('DracoWriter#encode(bunny.drc)', async t => {
   };
 
   for (const tc of TEST_CASES) {
-    const mesh = tc.options.pointcloud ? POINTCLOUD : MESH;
+    const mesh = tc.options.draco.pointcloud ? POINTCLOUD : MESH;
     const meshSize = _getMeshSize(mesh.attributes);
 
     const compressedMesh = await encode(mesh, DracoWriter, tc.options);
@@ -95,7 +99,7 @@ test('DracoParser#encode(bunny.drc)', async t => {
   };
 
   for (const tc of TEST_CASES) {
-    const attributes = tc.options.pointcloud ? pointCloudAttributes : meshAttributes;
+    const attributes = tc.options.draco.pointcloud ? pointCloudAttributes : meshAttributes;
     const meshSize = _getMeshSize(attributes);
 
     const compressedMesh = await encode(attributes, DracoWriter, tc.options);

--- a/modules/draco/test/draco.bench.js
+++ b/modules/draco/test/draco.bench.js
@@ -29,7 +29,7 @@ export default async function dracoBench(bench) {
     POSITIONS: new Float32Array(POSITIONS),
     COLORS: new Uint8ClampedArray(COLORS)
   };
-  const rawSize = _getMeshSize(attributes);
+  // const rawSize = _getMeshSize(attributes);
 
   for (const options of OPTIONS) {
     const compressedPointCloud = await encode(attributes, DracoWriter, {draco: {pointcloud: true}});
@@ -41,12 +41,13 @@ export default async function dracoBench(bench) {
       }
     );
 
-    bench.addAsync(
-      `DracoDecoder#pointcloud ${POSITIONS.byteLength / 12}#${options.name}`,
-      async () => {
-        return await parse(compressedPointCloud, DracoLoader, {worker: false});
-      }
-    );
+    // TODO - COMMENT OUT until bench.addAsync is fixed (too many invocations)
+    // bench.addAsync(
+    //   `DracoDecoder#pointcloud ${POSITIONS.byteLength / 12}#${options.name}`,
+    //   async () => {
+    //     return await parse(compressedPointCloud, DracoLoader, {worker: false});
+    //   }
+    // );
   }
 
   return bench;

--- a/modules/draco/test/draco.bench.js
+++ b/modules/draco/test/draco.bench.js
@@ -1,5 +1,4 @@
 import {fetchFile, encode} from '@loaders.gl/core';
-import {_getMeshSize} from '@loaders.gl/loader-utils';
 import {DracoWriter} from '@loaders.gl/draco';
 
 const OPTIONS = [
@@ -29,11 +28,8 @@ export default async function dracoBench(bench) {
     POSITIONS: new Float32Array(POSITIONS),
     COLORS: new Uint8ClampedArray(COLORS)
   };
-  // const rawSize = _getMeshSize(attributes);
 
   for (const options of OPTIONS) {
-    const compressedPointCloud = await encode(attributes, DracoWriter, {draco: {pointcloud: true}});
-
     bench.addAsync(
       `DracoEncoder#pointcloud ${POSITIONS.byteLength / 12}#${options.name}`,
       async () => {
@@ -42,6 +38,7 @@ export default async function dracoBench(bench) {
     );
 
     // TODO - COMMENT OUT until bench.addAsync is fixed (too many invocations)
+    // const compressedPointCloud = await encode(attributes, DracoWriter, {draco: {pointcloud: true}});
     // bench.addAsync(
     //   `DracoDecoder#pointcloud ${POSITIONS.byteLength / 12}#${options.name}`,
     //   async () => {

--- a/modules/draco/test/draco.bench.js
+++ b/modules/draco/test/draco.bench.js
@@ -1,6 +1,6 @@
-import {fetchFile, parse, encode} from '@loaders.gl/core';
+import {fetchFile, encode} from '@loaders.gl/core';
 import {_getMeshSize} from '@loaders.gl/loader-utils';
-import {DracoLoader, DracoWriter} from '@loaders.gl/draco';
+import {DracoWriter} from '@loaders.gl/draco';
 
 const OPTIONS = [
   {

--- a/modules/gltf/src/lib/deprecated/gltf-builder.js
+++ b/modules/gltf/src/lib/deprecated/gltf-builder.js
@@ -171,7 +171,7 @@ export default class GLTFBuilder extends GLBBuilder {
     }
 
     attributes.mode = 0;
-    const compressedData = this.DracoWriter.encodeSync(attributes, {pointcloud: true});
+    const compressedData = this.DracoWriter.encodeSync(attributes, {draco: {pointcloud: true}});
 
     const bufferViewIndex = this.addBufferView(compressedData);
 

--- a/modules/gltf/src/lib/extensions/UBER_draco_point_cloud_compression.js
+++ b/modules/gltf/src/lib/extensions/UBER_draco_point_cloud_compression.js
@@ -8,7 +8,7 @@ function addCompressedPointCloud(attributes, options) {
   }
 
   attributes.mode = 0;
-  const compressedData = options.DracoWriter.encodeSync(attributes, {pointcloud: true});
+  const compressedData = options.DracoWriter.encodeSync(attributes, {draco: {pointcloud: true}});
 
   const bufferViewIndex = this.addBufferView(compressedData);
 

--- a/modules/json/test/bench.js
+++ b/modules/json/test/bench.js
@@ -1,5 +1,0 @@
-import clarinetBench from './clarinet/clarinet.bench';
-
-export default async function jsonLoaderBench(suite) {
-  await clarinetBench(suite);
-}

--- a/modules/json/test/clarinet/clarinet.bench.js
+++ b/modules/json/test/clarinet/clarinet.bench.js
@@ -7,13 +7,13 @@ export default function clarinetBench(bench) {
 
   const parser = new ClarinetParser();
 
-  bench.group('Clarinet - JSON parsing');
+  bench.group('Clarinet - JSON parsing from string');
 
-  bench.add('ClarinetParser(basic.json)', () => {
-    parser.write(STRING);
+  bench.add('JSON.parse (used by parseSync)', () => {
+    JSON.parse(STRING);
   });
 
-  bench.add('JSON.parse(basic.json)', () => {
-    JSON.parse(STRING);
+  bench.add('ClarinetParser (used by parseInBatches)', () => {
+    parser.write(STRING);
   });
 }

--- a/modules/json/test/json-loader.bench.js
+++ b/modules/json/test/json-loader.bench.js
@@ -1,0 +1,26 @@
+import {JSONLoader} from '@loaders.gl/json';
+import {load, loadInBatches} from '@loaders.gl/core';
+
+import clarinetBench from './clarinet/clarinet.bench';
+
+const GEOJSON_URL = '@loaders.gl/json/test/data/geojson-big.json';
+
+export default async function jsonLoaderBench(suite) {
+  // Test underlying clarinet library
+  await clarinetBench(suite);
+
+  suite.group('JSONLoader - loading from file');
+
+  suite.addAsync('load(JSONLoader) - Uses JSON.parse', async () => {
+    await load(GEOJSON_URL, JSONLoader);
+  });
+
+  suite.addAsync('loadInBatches(JSONLoader) - Uses Clarinet', async () => {
+    const asyncIterator = await loadInBatches(GEOJSON_URL, JSONLoader);
+    // const asyncIterator = await parseInBatches(STRING, JSONLoader);
+    const data = [];
+    for await (const batch of asyncIterator) {
+      data.push(...batch.data);
+    }
+  });
+}

--- a/modules/json/test/json-loader.spec.js
+++ b/modules/json/test/json-loader.spec.js
@@ -60,6 +60,7 @@ test('JSONLoader#loadInBatches(geojson.json, rows, batchSize = 10)', async t => 
   t.end();
 });
 
+// TODO - columnar table batch support not yet fixed
 /*
 test('JSONLoader#loadInBatches(geojson.json, columns, batchSize = auto)', async t => {
   const iterator = await loadInBatches(GEOJSON_PATH, JSONLoader, {
@@ -72,7 +73,6 @@ test('JSONLoader#loadInBatches(geojson.json, columns, batchSize = auto)', async 
   let batch;
   let batchCount = 0;
   let rowCount = 0;
-
   for await (batch of iterator) {
     batchCount++;
     rowCount += batch.length;

--- a/package.json
+++ b/package.json
@@ -32,10 +32,6 @@
     "publish": "ocular-publish",
     "prepare": "npm run build",
     "test": "ocular-test",
-    "test-fast": "ocular-test fast",
-    "test-browser": "ocular-test browser",
-    "bench": "ocular-test bench",
-    "bench-browser": "ocular-test bench-browser",
     "metrics": "./scripts/metrics.sh && ocular-metrics"
   },
   "devDependencies": {
@@ -43,7 +39,7 @@
     "@luma.gl/core": "^8.0.0",
     "@luma.gl/debug": "^8.0.0",
     "@luma.gl/test-utils": "^8.0.0",
-    "@probe.gl/bench": "^3.1.1",
+    "@probe.gl/bench": "^3.2.0",
     "@probe.gl/test-utils": "^3.1.1",
     "arraybuffer-loader": "^1.0.7",
     "babel-loader": "^8.0.6",

--- a/test/bench/bench-modules.js
+++ b/test/bench/bench-modules.js
@@ -1,0 +1,42 @@
+// Copyright (c) 2015 - 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+/* eslint-disable no-console, no-invalid-this */
+import {Bench} from '@probe.gl/bench';
+
+import coreBench from '@loaders.gl/core/test/core.bench';
+import csvBench from '@loaders.gl/csv/test/csv.bench';
+import jsonBench from '@loaders.gl/json/test/json-loader.bench';
+import dracoBench from '@loaders.gl/draco/test/draco.bench';
+
+const suite = new Bench({
+  minIterations: 10
+});
+
+(async function bench() {
+  // add tests
+  await coreBench(suite);
+  await csvBench(suite);
+  await jsonBench(suite);
+  await dracoBench(suite);
+
+  // Run the suite
+  suite.run();
+})();

--- a/test/bench/index.js
+++ b/test/bench/index.js
@@ -1,45 +1,11 @@
-// Copyright (c) 2015 - 2017 Uber Technologies, Inc.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
+// Sets up aliases for file reader
+require('reify');
+
+require('@loaders.gl/polyfills');
 
 // Sets up aliases for file reader
-require('.../aliases');
+const ALIASES = require('../aliases');
+const {_addAliases} = require('@loaders.gl/loader-utils');
+_addAliases(ALIASES);
 
-/* eslint-disable no-console, no-invalid-this */
-import {Bench} from '@probe.gl/bench';
-
-import coreBench from '@loaders.gl/core/test/core.bench';
-import csvBench from '@loaders.gl/csv/test/csv.bench';
-import jsonBench from '@loaders.gl/json/test/json.bench';
-import dracoBench from '@loaders.gl/draco/test/draco.bench';
-
-const suite = new Bench({
-  minIterations: 10
-});
-
-(async function bench() {
-  // add tests
-  await coreBench(suite);
-  await csvBench(suite);
-  await jsonBench(suite);
-  await dracoBench(suite);
-
-  // Run the suite
-  suite.run();
-})();
+require('./bench-modules');

--- a/test/bench/node.js
+++ b/test/bench/node.js
@@ -1,0 +1,3 @@
+require('reify');
+
+require('./index');

--- a/test/render/test-cases/point-cloud.js
+++ b/test/render/test-cases/point-cloud.js
@@ -81,9 +81,11 @@ export default [
       const kittiPointCloudRaw = await loadKittiPointCloud();
       // Encode/decode mesh with Draco
       const compressedMesh = await encode({attributes: kittiPointCloudRaw}, DracoWriter, {
-        pointcloud: true,
-        quantization: {
-          POSITION: 14
+        draco: {
+          pointcloud: true,
+          quantization: {
+            POSITION: 14
+          }
         }
       });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1446,13 +1446,6 @@
     npmlog "^4.1.2"
     write-file-atomic "^2.3.0"
 
-"@loaders.gl/core@1.2.2":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/core/-/core-1.2.2.tgz#2c87b09e2e2a0d07c029d88d637757b85ce3dd38"
-  integrity sha512-c/ERkx2J2hWxEDxOLhU1XtOlqpn8TPGII2B31lu9nW3sv0MTqDVbM51R2TXthJ0uxenDz1ubhapiYyF5eA1eFw==
-  dependencies:
-    "@babel/runtime" "^7.3.1"
-
 "@loaders.gl/core@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@loaders.gl/core/-/core-2.0.0.tgz#ab84b94efb8ad3a90133389e5b76f6a721b20419"
@@ -1460,13 +1453,6 @@
   dependencies:
     "@babel/runtime" "^7.3.1"
     "@loaders.gl/loader-utils" "2.0.0"
-
-"@loaders.gl/experimental@1.2.2":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/experimental/-/experimental-1.2.2.tgz#cc253cf82e8b7fa7182f39c05f4243c53f6ab5d2"
-  integrity sha512-lyfw7pG7zFIDc6SkFIXubSjUFU5e8jvGLLrywXKYOGukHTJaOF6x2caYPrf57/x4pIp2r0IN4MNw/cilWJCikw==
-  dependencies:
-    "@loaders.gl/core" "1.2.2"
 
 "@loaders.gl/images@^2.0.0":
   version "2.0.0"
@@ -1663,7 +1649,7 @@
   dependencies:
     "@types/node" ">= 8"
 
-"@probe.gl/bench@^3.1.1":
+"@probe.gl/bench@^3.2.0":
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@probe.gl/bench/-/bench-3.2.0.tgz#323cf42e1b3fb33a93d0e5282c49fd050a3b063f"
   integrity sha512-nAEeRQIpo5eEBSmQ9O0RNp2I6jxrAVEzZnpPBa5Bkc1TrD40S9Eu/EqCUkxcQDTwNMKZIK6A4EIIIph5Qj3Rlg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2929,15 +2929,15 @@ command-line-usage@5.0.5:
     table-layout "^0.4.3"
     typical "^2.6.1"
 
+commander@2, commander@^2.18.0, commander@^2.20.0, commander@~2.20.3:
+  version "2.20.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
+  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
+
 commander@2.17.x:
   version "2.17.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
   integrity sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==
-
-commander@^2.18.0, commander@^2.20.0, commander@~2.20.3:
-  version "2.20.3"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
-  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
 commander@^4.0.1:
   version "4.0.1"
@@ -3324,6 +3324,15 @@ cyclist@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
+
+d3-dsv@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/d3-dsv/-/d3-dsv-1.2.0.tgz#9d5f75c3a5f8abd611f74d3f5847b0d4338b885c"
+  integrity sha512-9yVlqvZcSOMhCYzniHE7EVUws7Fa1zgw+/EAV2BxJoG3ME19V6BQFBwI855XQDsxyOuG7NibqRMTtiF/Qup46g==
+  dependencies:
+    commander "2"
+    iconv-lite "0.4"
+    rw "1"
 
 dargs@^4.0.1:
   version "4.1.0"
@@ -5231,7 +5240,7 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
+iconv-lite@0.4, iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -8416,6 +8425,11 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   integrity sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=
   dependencies:
     aproba "^1.1.1"
+
+rw@1:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/rw/-/rw-1.3.3.tgz#3f862dfa91ab766b14885ef4d01124bfda074fb4"
+  integrity sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q=
 
 rxjs@^6.4.0, rxjs@^6.5.3:
   version "6.5.3"


### PR DESCRIPTION
Adds benchmarks for JSON, comparing to `JSON.parse`. Also adds an (unfortunately unfavorable) comparison to d3-csv for the  `CSVLoader`

```
CSV Decode
├─ CSVLoader#parse: 279 iterations/s ±3.77%
├─ d3-dsv#parse: 2.13K iterations/s ±2.57%

Clarinet - JSON parsing from string
├─ JSON.parse (used by parseSync): 26.6K iterations/s ±3.55%
├─ ClarinetParser (used by parseInBatches): 7.15K iterations/s ±1.64%

JSONLoader - loading from file
├─ load(JSONLoader) - Uses JSON.parse: 717 iterations/s ±6.61%
├─ loadInBatches(JSONLoader) - Uses Clarinet: 204 iterations/s ±19.31%
```