### PR TITLE
images: fix ImageBitmap loading, add benchmarks/tests

### DIFF
--- a/modules/core/test/lib/loader-utils/normalize-loader.spec.js
+++ b/modules/core/test/lib/loader-utils/normalize-loader.spec.js
@@ -56,8 +56,8 @@ test('registerLoaders#normalizeLoader', t => {
     },
     {
       title: 'loader with options',
-      input: [images.ImageLoader, {images: {imageOrientation: 'flipY'}}],
-      options: {images: {imageOrientation: 'flipY'}}
+      input: [images.ImageLoader, {image: {imageOrientation: 'flipY'}}],
+      options: {image: {imageOrientation: 'flipY'}}
     },
     {
       title: 'extension field',

--- a/modules/images/src/image-loader.js
+++ b/modules/images/src/image-loader.js
@@ -27,7 +27,7 @@ const ImageLoader = {
     return isJpeg(dataView) || isBmp(dataView) || isGif(dataView) || isPng(dataView);
   },
   options: {
-    images: {
+    image: {
       format: 'auto',
       decodeHTML: true // if format is HTML
     }

--- a/modules/images/src/lib/parsed-image-api/image-type.js
+++ b/modules/images/src/lib/parsed-image-api/image-type.js
@@ -3,12 +3,14 @@ import {global, isBrowser} from '../utils/globals';
 import assert from '../utils/assert';
 
 export const IMAGE_BITMAP_SUPPORTED = typeof ImageBitmap !== 'undefined';
-export const HTML_IMAGE_SUPPORTED = typeof Image !== undefined; // NOTE: "false" positives if jsdom is installed
+export const HTML_IMAGE_SUPPORTED = typeof Image !== 'undefined'; // NOTE: "false" positives if jsdom is installed
 export const NODE_IMAGE_SUPPORTED = Boolean(global._parseImageNode);
 
 // Checks if a loaders.gl image type is supported
 export function isImageTypeSupported(type) {
   switch (type) {
+    case 'auto':
+      return true;
     case 'imagebitmap':
       return IMAGE_BITMAP_SUPPORTED;
     case 'html':

--- a/modules/images/src/lib/parsed-image-api/parsed-image-api.js
+++ b/modules/images/src/lib/parsed-image-api/parsed-image-api.js
@@ -43,6 +43,8 @@ export function getImageData(image) {
       const canvas = document.createElement('canvas');
       // TODO - reuse the canvas?
       const context = canvas.getContext('2d');
+      canvas.width = image.width;
+      canvas.height = image.height;
       context.drawImage(image, 0, 0);
       const imageData = context.getImageData(0, 0, image.width, image.height);
       return imageData.data;

--- a/modules/images/src/lib/parsers/parse-image.js
+++ b/modules/images/src/lib/parsers/parse-image.js
@@ -8,9 +8,7 @@ import parseSVG from './parse-svg';
 
 // Parse to platform defined image type (ndarray on node, ImageBitmap or HTMLImage on browser)
 export default async function parseImage(arrayBuffer, options, context) {
-  if ('image' in options) {
-    options = {...options, image: {}};
-  }
+  options = options || {};
 
   const {url} = context || {};
   if (url && /\.svg((\?|#).*)?$/.test(url)) {

--- a/modules/images/test/image-loader.spec.js
+++ b/modules/images/test/image-loader.spec.js
@@ -1,9 +1,11 @@
 import test from 'tape-promise/tape';
 
-import {ImageLoader, getImageSize} from '@loaders.gl/images';
+import {ImageLoader, getImageSize, isImageTypeSupported} from '@loaders.gl/images';
 import {isBrowser, load} from '@loaders.gl/core';
 
 import {TEST_CASES, DATA_URL} from './lib/test-cases';
+
+const TYPES = ['auto', 'imagebitmap', 'html', 'ndarray'].filter(isImageTypeSupported);
 
 const TEST_URL = '@loaders.gl/images/test/data/img1-preview.png';
 
@@ -13,22 +15,29 @@ test('image loaders#imports', t => {
 });
 
 test('ImageLoader#load(URL)', async t => {
-  const image = await load(TEST_URL, ImageLoader);
+  let image = await load(TEST_URL, ImageLoader);
   t.ok(image, 'image loaded successfully from URL');
+
+  for (const type of TYPES) {
+    image = await load(TEST_URL, ImageLoader, {image: {type}});
+    t.ok(image, 'image loaded successfully from URL');
+  }
+
   t.end();
 });
 
 test('ImageLoader#load(data URL)', async t => {
-  const image = await load(DATA_URL, ImageLoader);
-  t.ok(image, 'image loaded successfully from data URL');
+  for (const type of TYPES) {
+    const image = await load(DATA_URL, ImageLoader, {image: {type}});
+    t.ok(image, 'image loaded successfully from data URL');
 
-  t.deepEquals(image.width, 2, 'image width is correct');
-  t.deepEquals(image.height, 2, 'image height is correct');
-  if (!isBrowser) {
-    t.ok(ArrayBuffer.isView(image.data), 'image data is `ArrayBuffer`');
-    t.equals(image.data.byteLength, 16, 'image `data.byteLength` is correct');
+    t.deepEquals(image.width, 2, 'image width is correct');
+    t.deepEquals(image.height, 2, 'image height is correct');
+    if (!isBrowser) {
+      t.ok(ArrayBuffer.isView(image.data), 'image data is `ArrayBuffer`');
+      t.equals(image.data.byteLength, 16, 'image `data.byteLength` is correct');
+    }
   }
-
   t.end();
 });
 

--- a/modules/images/test/images.bench.js
+++ b/modules/images/test/images.bench.js
@@ -1,0 +1,19 @@
+import {ImageLoader, isImageTypeSupported} from '@loaders.gl/images';
+import {fetchFile, parse} from '@loaders.gl/core';
+
+const TEST_URL = '@loaders.gl/images/test/data/img1-preview.png';
+
+export default async function jsonLoaderBench(suite) {
+  suite.group('ImageLoader - parsing');
+
+  const response = await fetchFile(TEST_URL);
+  const arrayBuffer = await response.arrayBuffer();
+
+  for (const type of ['html', 'imagebitmap', 'ndarray']) {
+    if (isImageTypeSupported(type)) {
+      suite.addAsync(`load(ImageLoader, type=${type})`, async () => {
+        return await parse(arrayBuffer, ImageLoader, {image: {type}});
+      });
+    }
+  }
+}

--- a/modules/images/test/images.bench.js
+++ b/modules/images/test/images.bench.js
@@ -3,7 +3,7 @@ import {fetchFile, parse} from '@loaders.gl/core';
 
 const TEST_URL = '@loaders.gl/images/test/data/img1-preview.png';
 
-export default async function jsonLoaderBench(suite) {
+export default async function imageLoaderBench(suite) {
   suite.group('ImageLoader - parsing');
 
   const response = await fetchFile(TEST_URL);

--- a/test/bench/bench-modules.js
+++ b/test/bench/bench-modules.js
@@ -25,6 +25,7 @@ import coreBench from '@loaders.gl/core/test/core.bench';
 import csvBench from '@loaders.gl/csv/test/csv.bench';
 import jsonBench from '@loaders.gl/json/test/json-loader.bench';
 import dracoBench from '@loaders.gl/draco/test/draco.bench';
+import imageBench from '@loaders.gl/images/test/images.bench';
 
 const suite = new Bench({
   minIterations: 10
@@ -33,6 +34,7 @@ const suite = new Bench({
 (async function bench() {
   // add tests
   await coreBench(suite);
+  await imageBench(suite);
   await csvBench(suite);
   await jsonBench(suite);
   await dracoBench(suite);


### PR DESCRIPTION
Note: this PR does not change default image type, just fixes existing logic.

- Incorrect `options.images` references in code changed to `option.image` (correct per documentation).
- Fix to `getImageData`
- Fix `ImageBitmap` loading
- Add tests for loading different types

Adds `Benchmarks` comparing `imagebitmap` and `html`. Unsurprisingly the loading speed is quite similar, though once we have worker support in the `ImageLoader`, `ImageBitmap` could potentially have a significant advantage. They are also supposedly optimized for rendering...

<img width="536" alt="Screen Shot 2019-12-23 at 3 46 36 PM" src="https://user-images.githubusercontent.com/7025232/71385339-c1cfc880-259b-11ea-9efc-96db57629990.png">
