### PR TITLE
Fix double build

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,11 +26,11 @@
     "start": "echo 'Please see loaders.gl website for how to run examples' && open https://loaders.gl/docs",
     "bootstrap": "PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true yarn && ocular-bootstrap",
     "build": "ocular-clean && lerna run pre-build && ocular-build",
+    "build-workers": "lerna run pre-build",
     "clean": "ocular-clean",
     "cover": "ocular-test cover",
     "lint": "ocular-lint",
     "publish": "ocular-publish",
-    "prepare": "npm run build",
     "test": "ocular-test",
     "metrics": "./scripts/metrics.sh && ocular-metrics"
   },


### PR DESCRIPTION
@Pessimistress Right now I can't think of a reason that we need the offending `prepare` script but I assume there was a reason at some point...

I added a `build-workers` script as a convenience when I am iterating on the workers, it builds the scripts in 25s vs 75s for the full build.