### PR TITLE
Image data

### DIFF
--- a/docs/specifications/category-image.md
+++ b/docs/specifications/category-image.md
@@ -56,7 +56,7 @@ Image data objects are images loaded as data, represented by an object that cont
 
 To get an image data object from a loaded `Image` or `ImageBitmap`, call `getImageData(image)`. To load an image data object directly, set the `image.type: 'data'` option when loading the image.
 
-## Image Format
+### Image Formats
 
 The _format_ of the image describes how the memory is laid out. It is mainly important when working with `data` _type_ images. The default format / memory layout for image data is `RGBA` and `UNSIGNED_BYTE` i.e. four components per pixel, each a byte.
 
@@ -72,10 +72,10 @@ Applications that use e.g. the `CompressedTextureLoader` and/or the `BasisLoader
 
 The image category support some generic options (specified using `options.image.<option-name>`), that are applicable to all (or most) image loaders.
 
-| Option                     | Default  | Type    | Availability   | Description                                   |
-| -------------------------- | -------- | ------- | -------------- | --------------------------------------------- |
-| `options.image.type`       | `'auto'` | string  | See table      | One of `auto`, `data`, `imagebitmap`, `image` |
-| `options.image.decodeHTML` | `true`   | boolean | No: Edge, IE11 | Wait for HTMLImages to be fully decoded.      |
+| Option                 | Default  | Type    | Availability   | Description                                   |
+| ---------------------- | -------- | ------- | -------------- | --------------------------------------------- |
+| `options.image.type`   | `'auto'` | string  | See table      | One of `auto`, `data`, `imagebitmap`, `image` |
+| `options.image.decode` | `true`   | boolean | No: Edge, IE11 | Wait for HTMLImages to be fully decoded.      |
 
 ## Notes
 
@@ -92,10 +92,11 @@ The image category also provides a few utilities:
 
 ## Remarks
 
-- image data objects have the same fields as the browser's built-in `ImageData` class, but are not actual instances of `ImageData`. It is however easy to create an `ImageData` instance from an image data object:
+### ImageData
+
+Image data objects return by image category loaders have the same fields (`width`, `height`, `data`) as the browser's built-in `ImageData` class, but are not actual instances of `ImageData`. However, should you need it, it is easy to create an `ImageData` instance from an image data object:
 
 ```js
-const imageData = new ImageData(imagedata.data, imagedata.width, imagedata.height);
+const data = load(url, ImageLoader, {image: {type: 'data'}});
+const imageData = new ImageData(data.data, data.width, data.height);
 ```
-
-Note that this assumes its image _format_ is the default 8-bit RGBA.

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -9,6 +9,10 @@
 **`@loaders.gl/images`**
 
 The experimental ImageLoaders for individual formats introduced in 2.0 have been removed, use `ImageLoader` for all formats.
+`@loaders.gl/images`
+
+- `getImageData(image)` now returns an object with `{data, width, height}` instead of just the `data` array. This small breaking change ensures that the concept of _image data_ is consistent across the API.
+- `ImageLoader`: `options.image.type`: The `html` and `ndarray` image types are now deprecated and replaced with `image` and `data` respectively.
 
 ## Upgrading to v2.0
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -10,7 +10,8 @@ Target Release Date: mid-Feb, 2019. `alpha` releases will be made available.
 
 **@loaders.gl/images**
 
-- `ImageBitmap` Loading: `load(..., ImageLoader, {image: {type 'imagebitmap'}}) => ImageBitmap`
+- Images can now be loaded as data: Using the `ImageLoader` with `options.image.type: 'data'` parameter will return an _image data object_ with width, height and a typed array containing the image data (instead of an opaque `Image` or `ImageBitmap` instance).
+- `ImageBitmap` loading now works reliably, use `ImageLoader` with `options.image.type: 'imagebitmap'`.
 
 **@loaders.gl/json**
 
@@ -57,7 +58,7 @@ The 2.0 release brings potentially dramatic bundle size savings through dynamic 
   - `options.image.type`, Ability to control loaded image type enabling faster `ImageBitmap` instances to be loaded via `type: 'imagebitmap`. Default `auto` setting returns traditional HTML image objects.
 - Image Decoding. `options.image.decodeHTML: true` - `ImageLoader` now ensures HTML images are completely decoded and ready to be used when the image is returned (by calling `Image.decode()`).
 
-- **Parsed Image API** Since the type of images returned by the `ImageLoader` depends on the `{image: {type: ...}}` option, a set of functions are provided to work portably with loaded images: `isImage()`, `getImageType()`, `getImageSize()`, `getImageData()`, ...
+- **Parsed Image API** Since the type of images returned by the `ImageLoader` depends on the `{image: {type: ...}}` option, a set of functions are provided to work portably with loaded images: `isImage()`, `getImageType()`, `getImageData()`, ...
 - **Binary Image API** Separate API to work with unparsed images in binary data form: `isBinaryImage()`, `getBinaryImageType()`, `getBinaryImageSize()`, ...
 - **"Texture" Loading API** New methods `loadImages` and `loadImageCube` can signficantly simplify loading of arrays of arrays of (mipmapped) images that are often used in 3D applications. These methods allow an entire complex of images (e.g. 6 cube faces with 10 mip images each) to be loaded using a single async call.
 - **Improved Node.js support** More image test cases are now run in both browser and Node.js and a couple of important Node.js issues were uncovered and fixed.

--- a/modules/images/docs/api-reference/image-loader.md
+++ b/modules/images/docs/api-reference/image-loader.md
@@ -7,7 +7,7 @@ An image loader that works under both Node.js (requires `@loaders.gl/polyfills`)
 | File Extension | `.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`, `.bmp`, `.ico`, `.svg` |
 | File Type      | Binary                                                           |
 | File Format    | Image                                                            |
-| Data Format    | `ImageBitmap`, `Image` (older browsers) or ndarray (node.js)     |
+| Data Format    | `ImageBitmap`, `Image` (older browsers) or `data` (node.js)      |
 | Supported APIs | `load`, `parse`                                                  |
 
 ## Usage
@@ -22,11 +22,10 @@ const image = await load(url, ImageLoader, options);
 
 ## Options
 
-| Option         | Type    | Default  | Description                                                                                                                 |
-| -------------- | ------- | -------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `image.type`   | String  | `'auto'` | Set to `imagebitmap`, `image` or `ndarray` to control type of returned image.                                               |
-| `image.data`   | boolean | `false`  | If true, extracts image data instead of returning an actual image, as an `ImageData`-shaped object `{widht, height, data}`. |
-| `image.decode` | boolean | `true`   | Applies to `image` type images only, ensures image is fully decoded before loading promise resolves.                        |
+| Option         | Type    | Default  | Description                                                                                          |
+| -------------- | ------- | -------- | ---------------------------------------------------------------------------------------------------- |
+| `image.type`   | String  | `'auto'` | Set to `data`, `imagebitmap` or `image` to control type of returned image.                           |
+| `image.decode` | boolean | `true`   | Applies to `image` type images only, ensures image is fully decoded before loading promise resolves. |
 
 ### ImageBitmap Options
 
@@ -41,7 +40,7 @@ In addition, for `imagebitmap` type images, it is possible to pass through optio
 | `imagebitmap.resizeHeight`         | number | -           | Output image height.                                                                                                          |
 | `imagebitmap.resizeQuality`        | string | `'low'`     | Algorithm to be used for resizing the input to match the output dimensions. One of pixelated, low (default), medium, or high. |
 
-Portability note: The exact set of `imagebitmap` options supported may depend on the browser, and also do not apply to `html` or `ndarray` images.
+Portability note: The exact set of `imagebitmap` options supported may depend on the browser.
 
 ## Remarks
 

--- a/modules/images/docs/api-reference/parsed-image-api.md
+++ b/modules/images/docs/api-reference/parsed-image-api.md
@@ -47,11 +47,11 @@ Throws
 
 - if `image` is not of a recognized type.
 
-| Type          | JavaScript Type                                 | Description                                        |
-| ------------- | ----------------------------------------------- | -------------------------------------------------- |
-| `data`        | Image data object: `data`, `width`, `height` .. | Node.js representation                             |
-| `imagebitmap` | `ImageBitmap`                                   | The newer HTML5 image class (modern browsers only) |
-| `image`       | `Image` aka `HTMLImageElement`                  | The older, less flexible HTML image element        |
+| Type          | JavaScript Type                                 | Description                                                          |
+| ------------- | ----------------------------------------------- | -------------------------------------------------------------------- |
+| `data`        | Image data object: `data`, `width`, `height` .. | Node.js representation                                               |
+| `imagebitmap` | `ImageBitmap`                                   | The newer HTML5 image class (modern browsers only)                   |
+| `image`       | `Image` aka `HTMLImageElement`                  | More widely supported (but less performant and flexible) image class |
 
 ### getImageData(image : any) : Object
 

--- a/modules/images/src/lib/parsed-image-api/image-type.js
+++ b/modules/images/src/lib/parsed-image-api/image-type.js
@@ -1,42 +1,48 @@
 /* global ImageBitmap, Image */
 import {global, isBrowser} from '../utils/globals';
-import assert from '../utils/assert';
 
-export const IMAGE_BITMAP_SUPPORTED = typeof ImageBitmap !== 'undefined';
-export const HTML_IMAGE_SUPPORTED = typeof Image !== 'undefined'; // NOTE: "false" positives if jsdom is installed
-export const NODE_IMAGE_SUPPORTED = Boolean(global._parseImageNode);
+const IMAGE_SUPPORTED = typeof Image !== 'undefined'; // NOTE: "false" positives if jsdom is installed
+const IMAGE_BITMAP_SUPPORTED = typeof ImageBitmap !== 'undefined';
+const NODE_IMAGE_SUPPORTED = Boolean(global._parseImageNode);
 
 // Checks if a loaders.gl image type is supported
 export function isImageTypeSupported(type) {
   switch (type) {
     case 'auto':
-      return true;
+      // Should only ever be false in Node.js, if polyfills have not been installed...
+      return IMAGE_BITMAP_SUPPORTED || IMAGE_SUPPORTED || NODE_IMAGE_SUPPORTED;
+
     case 'imagebitmap':
       return IMAGE_BITMAP_SUPPORTED;
-    case 'html':
-      return HTML_IMAGE_SUPPORTED;
-    case 'ndarray':
-      return NODE_IMAGE_SUPPORTED;
+
+    case 'html': // type `html` is deprecated, use `image`
+    // eslint-disable-next-line no-fallthrough
+    case 'image':
+      return IMAGE_SUPPORTED;
+
+    case 'ndarray': // type `ndarray` is deprecated, use 'data'
+    // eslint-disable-next-line no-fallthrough
+    case 'data':
+      return isBrowser ? true : NODE_IMAGE_SUPPORTED;
+
     default:
-      throw new Error(`Unknown image format ${type}`);
+      throw new Error(`@loaders.gl/images: image ${type} not supported in this environment`);
   }
 }
 
 // Returns the best loaders.gl image type supported on current run-time environment
 export function getDefaultImageType() {
-  if (isImageTypeSupported('ndarray')) {
-    return 'ndarray';
-  }
-  if (isImageTypeSupported('html')) {
-    return 'html';
+  // TODO - switch order... we want to return imagebitmap by default
+  if (isImageTypeSupported('image')) {
+    return 'image';
   }
   if (isImageTypeSupported('imagebitmap')) {
     return 'imagebitmap';
   }
-
-  if (!isBrowser) {
-    throw new Error(`Install '@loaders.gl/polyfills' to parse images under Node.js`);
+  if (isImageTypeSupported('data')) {
+    return 'data';
   }
 
-  return assert(false); // Internal error, no valid format available, should not happen
+  // This should only happen in Node.js
+  throw new Error(`Install '@loaders.gl/polyfills' to parse images under Node.js`);
 }

--- a/modules/images/src/lib/parsers/parse-image.js
+++ b/modules/images/src/lib/parsers/parse-image.js
@@ -1,57 +1,68 @@
 import assert from '../utils/assert';
 import {isImageTypeSupported, getDefaultImageType} from '../parsed-image-api/image-type';
-
-import parseToNodeImage from './parse-to-node-image';
+import {getImageData} from '../parsed-image-api/parsed-image-api';
 import parseToImage from './parse-to-image';
 import parseToImageBitmap from './parse-to-image-bitmap';
+import parseToNodeImage from './parse-to-node-image';
 import parseSVG from './parse-svg';
 
 const SVG_DATA_URL_PATTERN = /^data:image\/svg\+xml/;
 const SVG_URL_PATTERN = /\.svg((\?|#).*)?$/;
 
-// Parse to platform defined image type (ndarray on node, ImageBitmap or HTMLImage on browser)
+// Parse to platform defined image type (data on node, ImageBitmap or HTMLImage on browser)
+// eslint-disable-next-line complexity
 export default async function parseImage(arrayBuffer, options, context) {
   options = options || {};
+  const imageOptions = options.image || {};
+
+  // The user can request a specific output format via `options.image.type`
+  const imageType = imageOptions.type || 'auto';
 
   const {url} = context || {};
   if (url && (SVG_DATA_URL_PATTERN.test(url) || SVG_URL_PATTERN.test(url))) {
+    // TODO - This path does not handle the same options...
+    // eslint-disable-next-line
+    console.warn('@loaders.gl/images: SVG parsing is limited, not all options supported');
     return await parseSVG(arrayBuffer, options);
   }
 
-  const format = getImageOutputFormat(options);
-  switch (format) {
+  // Note: For options.image.type === `data`, we may still need to load as `image` or `imagebitmap`
+  const loadType = getLoadableImageType(imageType);
+
+  let image;
+  switch (loadType) {
     case 'imagebitmap':
       return await parseToImageBitmap(arrayBuffer, options);
-    case 'html':
-      return await parseToImage(arrayBuffer, options);
-    case 'ndarray':
-      return await parseToNodeImage(arrayBuffer, options);
+    case 'image':
+      image = await parseToImage(arrayBuffer, options);
+      break;
+    case 'data':
+      // Node.js loads imagedata directly
+      image = await parseToNodeImage(arrayBuffer, options);
+      break;
     default:
-      return assert(false);
+      assert(false);
   }
+
+  // Browser: if options.image.type === 'data', we can now extract data from the loaded image
+  if (imageType === 'data') {
+    image = getImageData(image, false);
+  }
+
+  return image;
 }
 
-// The user can request a specific output format via `options.type`
-// TODO - ImageBitmap vs HTMLImage depends on worker threads...
-function getImageOutputFormat(options = {}) {
-  const imageOptions = options.image || {};
-  const type = imageOptions.type || 'auto';
-
+// Get a loadable image type from image type
+function getLoadableImageType(type) {
   switch (type) {
-    case 'imagebitmap':
-    case 'html':
-    case 'ndarray':
-      // Check that it is actually supported
-      if (!isImageTypeSupported(type)) {
-        throw new Error(`Requested image type ${type} not available in current environment`);
-      }
-      return type;
-
     case 'auto':
+    case 'data':
+      // Browser: For image data we need still need to load using an image format
+      // Node: the default image type is `data`.
       return getDefaultImageType();
-
     default:
-      // Note: isImageTypeSupported throws on unknown type
-      throw new Error(`Unknown image format ${type}`);
+      // Throw an error if not supported
+      isImageTypeSupported(type);
+      return type;
   }
 }

--- a/modules/images/test/image-loader.spec.js
+++ b/modules/images/test/image-loader.spec.js
@@ -4,7 +4,6 @@ import {ImageLoader, isImageTypeSupported, getImageType, getImageData} from '@lo
 import {isBrowser, load} from '@loaders.gl/core';
 
 import {TEST_CASES, IMAGE_URL, IMAGE_DATA_URL, SVG_DATA_URL} from './lib/test-cases';
-import {getImageSize} from '../dist/es5/lib/parsed-image-api/parsed-image-api';
 
 const TYPES = ['auto', 'imagebitmap', 'image', 'data'].filter(isImageTypeSupported);
 
@@ -42,7 +41,7 @@ test(`ImageLoader#load({type: 'data'})`, async t => {
     const {title, url, width, height, skip} = testCase;
 
     // Skip some test case under Node.js
-    if (skip) {
+    if (skip || title.toLowerCase().includes('svg')) {
       return;
     }
 

--- a/modules/images/test/image-loader.spec.js
+++ b/modules/images/test/image-loader.spec.js
@@ -1,12 +1,12 @@
 import test from 'tape-promise/tape';
 
-import {ImageLoader, isImageTypeSupported, getImageData} from '@loaders.gl/images';
+import {ImageLoader, isImageTypeSupported, getImageType, getImageData} from '@loaders.gl/images';
 import {isBrowser, load} from '@loaders.gl/core';
 
 import {TEST_CASES, IMAGE_URL, IMAGE_DATA_URL, SVG_DATA_URL} from './lib/test-cases';
 import {getImageSize} from '../dist/es5/lib/parsed-image-api/parsed-image-api';
 
-const TYPES = ['auto', 'imagebitmap', 'html', 'ndarray'].filter(isImageTypeSupported);
+const TYPES = ['auto', 'imagebitmap', 'image', 'data'].filter(isImageTypeSupported);
 
 test('image loaders#imports', t => {
   t.ok(ImageLoader, 'ImageLoader defined');
@@ -26,7 +26,7 @@ test('ImageLoader#load(data URL)', async t => {
     const image = await load(IMAGE_DATA_URL, ImageLoader, {image: {type}});
     t.ok(image, `image of type ${type} loaded successfully from data URL`);
 
-    const imageData = {...getImageSize(image), data: getImageData(image)};
+    const imageData = getImageData(image);
     t.deepEquals(imageData.width, 2, 'image width is correct');
     t.deepEquals(imageData.height, 2, 'image height is correct');
     if (!isBrowser) {
@@ -34,6 +34,25 @@ test('ImageLoader#load(data URL)', async t => {
       t.equals(imageData.data.byteLength, 16, 'image `data.byteLength` is correct');
     }
   }
+  t.end();
+});
+
+test(`ImageLoader#load({type: 'data'})`, async t => {
+  for (const testCase of TEST_CASES) {
+    const {title, url, width, height, skip} = testCase;
+
+    // Skip some test case under Node.js
+    if (skip) {
+      return;
+    }
+
+    const imageData = await load(url, ImageLoader, {image: {type: 'data'}});
+    t.equal(getImageType(imageData), 'data', `${title} image type is data`);
+    t.equal(getImageData(imageData), imageData, `${title} getImageData() works`);
+    t.equal(imageData.width, width, `${title} image has correct width`);
+    t.equal(imageData.height, height, `${title} image has correct height`);
+  }
+
   t.end();
 });
 

--- a/modules/images/test/images.bench.js
+++ b/modules/images/test/images.bench.js
@@ -44,4 +44,12 @@ export default async function imageLoaderBench(suite) {
       );
     }
   }
+
+  // for (const type of ['image', 'imagebitmap', 'data']) {
+  //   if (isImageTypeSupported(type)) {
+  //     suite.addAsync(`parse(ImageLoader, type=${type}, data=true)`, async () => {
+  //       return await parse(arrayBuffer, ImageLoader, {image: {type, data: true}});
+  //     });
+  //   }
+  // }
 }

--- a/modules/images/test/lib/parsed-image-api.spec.js
+++ b/modules/images/test/lib/parsed-image-api.spec.js
@@ -12,7 +12,7 @@ import {
   getImageData
 } from '@loaders.gl/images';
 
-const IMAGE_TYPES = ['auto', 'imagebitmap', 'html', 'ndarray'];
+const IMAGE_TYPES = ['auto', 'image', 'imagebitmap', 'data'];
 
 const IMAGE_URL = '@loaders.gl/images/test/data/img1-preview.png';
 


### PR DESCRIPTION
- Replace `options.image.type: 'ndarray'` for Node.js with `options.image.type: 'data'`
- Support `options.image.type: 'data'` this on both Node.js and browser. 
- Continued cleanup and consolidation of the extensive image category docs

Apart from unifying the API and making it easy to load image data for image textures, also enables moving pixel extraction into the image worker (next PR), increasing parallel throughput of data texture loading.

