### PR TITLE
core: Fix parse of embedded typedArrays and Buffers

### DIFF
--- a/modules/core/src/javascript-utils/is-type.js
+++ b/modules/core/src/javascript-utils/is-type.js
@@ -34,6 +34,9 @@ export const isReadableDOMStream = x => {
   );
 };
 
+// Check for Node.js `Buffer` without triggering bundler to include polyfill
+export const isBuffer = x => x && typeof x === 'object' && x.isBuffer;
+
 export const isWritableNodeStream = x => {
   return isObject(x) && isFunction(x.end) && isFunction(x.write) && isBoolean(x.writable);
 };

--- a/modules/core/src/lib/loader-utils/get-data.js
+++ b/modules/core/src/lib/loader-utils/get-data.js
@@ -32,11 +32,20 @@ export function getArrayBufferOrStringFromDataSync(data, loader) {
     return data;
   }
 
-  if (data instanceof ArrayBuffer || ArrayBuffer.isView(data)) {
-    const arrayBuffer = data.buffer || data;
+  if (data instanceof ArrayBuffer) {
+    const arrayBuffer = data;
     if (loader.text && !loader.binary) {
       const textDecoder = new TextDecoder('utf8');
       return textDecoder.decode(arrayBuffer);
+    }
+    return arrayBuffer;
+  }
+
+  if (ArrayBuffer.isView(data) || data.buffer) {
+    const arrayBuffer = data.buffer || data;
+    if (loader.text && !loader.binary) {
+      const textDecoder = new TextDecoder('utf8');
+      return textDecoder.decode(data);
     }
     return arrayBuffer;
   }

--- a/modules/core/src/lib/loader-utils/get-data.js
+++ b/modules/core/src/lib/loader-utils/get-data.js
@@ -51,14 +51,15 @@ export function getArrayBufferOrStringFromDataSync(data, loader) {
       return textDecoder.decode(data);
     }
 
+    let arrayBuffer = data.buffer;
+
     // Since we are returning the underlying arrayBuffer, we must create a new copy
+    // if this typed array / Buffer is a partial view into the ArryayBuffer
     // TODO - this is a potentially unnecessary copy
     const byteLength = data.byteLength || data.length;
-
-    let arrayBuffer = data.buffer;
     if (data.byteOffset !== 0 || byteLength !== arrayBuffer.byteLength) {
-      console.warn('loaders.gl copying arraybuffer');
-      return arrayBuffer.slice(data.byteOffset, data.byteOffset, byteLength || data.length);
+      // console.warn(`loaders.gl copying arraybuffer of length ${byteLength}`);
+      arrayBuffer = arrayBuffer.slice(data.byteOffset, data.byteOffset + byteLength);
     }
     return arrayBuffer;
   }

--- a/modules/core/test/lib/loader-utils/get-data.spec.js
+++ b/modules/core/test/lib/loader-utils/get-data.spec.js
@@ -26,7 +26,7 @@ test('parseWithLoader#getArrayBufferOrStringFromDataSync', t => {
   t.end();
 });
 
-test.only('parseWithLoader#getArrayBufferOrStringFromDataSync(embedded arrays/buffers)', t => {
+test('parseWithLoader#getArrayBufferOrStringFromDataSync(embedded arrays/buffers)', t => {
   const string = 'line 1\nline 2';
   const embeddedString = `}}}${string}{{{`;
 

--- a/modules/core/test/lib/loader-utils/get-data.spec.js
+++ b/modules/core/test/lib/loader-utils/get-data.spec.js
@@ -1,4 +1,4 @@
-/* global TextEncoder */
+/* global TextEncoder, TextDecoder, Buffer */
 import test from 'tape-promise/tape';
 import {
   getArrayBufferOrStringFromDataSync,
@@ -37,19 +37,24 @@ test.only('parseWithLoader#getArrayBufferOrStringFromDataSync(embedded arrays/bu
   let extractedString = new TextDecoder().decode(typedArrayWithOffset);
   t.equals(extractedString, string);
 
-
   let result = getArrayBufferOrStringFromDataSync(typedArrayWithOffset, {text: true});
-  t.equals(result, string, 'typedArrayWithOffset returns correct result');
+  t.equals(result, string, 'typedArrayWithOffset to string returns correct result');
+
+  // result = getArrayBufferOrStringFromDataSync(typedArrayWithOffset, {text: false});
+  // t.deepEquals(result, typedArrayWithOffset, 'typedArrayWithOffset to ArrayBuffer returns correct result');
 
   if (!isBrowser) {
     const nodeBufferWithOffset = Buffer.from(typedArray.buffer, 3, string.length);
-  
+
     // Check that our offset array is correctly set up
     extractedString = nodeBufferWithOffset.toString();
     t.equals(extractedString, string);
 
-    let result = getArrayBufferOrStringFromDataSync(nodeBufferWithOffset, {text: true});
-    t.equals(result, string, 'typedArrayWithOffset returns correct result');  
+    result = getArrayBufferOrStringFromDataSync(nodeBufferWithOffset, {text: true});
+    t.equals(result, string, 'BufferWithOffset to string returns correct result');
+
+    // result = getArrayBufferOrStringFromDataSync(nodeBufferWithOffset, {text: false});
+    // t.deepEquals(result, typedArrayWithOffset, 'BufferWithOffset to ArrayBuffer returns correct result');
   }
 
   t.end();

--- a/modules/core/test/lib/loader-utils/get-data.spec.js
+++ b/modules/core/test/lib/loader-utils/get-data.spec.js
@@ -40,8 +40,12 @@ test.only('parseWithLoader#getArrayBufferOrStringFromDataSync(embedded arrays/bu
   let result = getArrayBufferOrStringFromDataSync(typedArrayWithOffset, {text: true});
   t.equals(result, string, 'typedArrayWithOffset to string returns correct result');
 
-  // result = getArrayBufferOrStringFromDataSync(typedArrayWithOffset, {text: false});
-  // t.deepEquals(result, typedArrayWithOffset, 'typedArrayWithOffset to ArrayBuffer returns correct result');
+  result = getArrayBufferOrStringFromDataSync(typedArrayWithOffset, {text: false});
+  t.deepEquals(
+    new Uint8Array(result),
+    typedArrayWithOffset,
+    'typedArrayWithOffset to ArrayBuffer returns correct result'
+  );
 
   if (!isBrowser) {
     const nodeBufferWithOffset = Buffer.from(typedArray.buffer, 3, string.length);
@@ -53,8 +57,12 @@ test.only('parseWithLoader#getArrayBufferOrStringFromDataSync(embedded arrays/bu
     result = getArrayBufferOrStringFromDataSync(nodeBufferWithOffset, {text: true});
     t.equals(result, string, 'BufferWithOffset to string returns correct result');
 
-    // result = getArrayBufferOrStringFromDataSync(nodeBufferWithOffset, {text: false});
-    // t.deepEquals(result, typedArrayWithOffset, 'BufferWithOffset to ArrayBuffer returns correct result');
+    result = getArrayBufferOrStringFromDataSync(nodeBufferWithOffset, {text: false});
+    t.deepEquals(
+      new Uint8Array(result),
+      typedArrayWithOffset,
+      'BufferWithOffset to ArrayBuffer returns correct result'
+    );
   }
 
   t.end();


### PR DESCRIPTION
As discovered by @isaacbrodsky, there were still instances where loaders.gl failed on "embedded" `Buffer` and typed array arguments since it just extracted the embedded arraybuffer without regards for offsets.

This PR adds:
- initially failing tests for both embedded typed arrays and embedded `Buffer`s
- adds fixes for those tests.