### PR TITLE
core: Add `makeChunkIterator`. Improve iterator generator function naming.

### DIFF
--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -2,6 +2,15 @@
 
 ## Upgrading to v2.1
 
+**`@loaders.gl/core`**
+
+Some iterator helper functions have been renamed, the old naming is now deprecated.
+
+| Old Name                   | New Name                 |
+| -------------------------- | ------------------------ |
+| `getStreamIterator`        | `makeStreamIterator`     |
+| `contatenateAsyncIterator` | `concatenateChunksAsync` |
+
 **`@loaders.gl/json`**
 
 - Experimental exports have been removed `JSONParser`, `StreamingJSONParser`, `ClarinetParser`.

--- a/modules/arrow/test/arrow-loader.spec.js
+++ b/modules/arrow/test/arrow-loader.spec.js
@@ -2,7 +2,7 @@ import test from 'tape-promise/tape';
 import {validateLoader} from 'test/common/conformance';
 
 import {ArrowLoader, ArrowWorkerLoader} from '@loaders.gl/arrow';
-import {isBrowser, getStreamIterator, resolvePath} from '@loaders.gl/core';
+import {isBrowser, makeStreamIterator, resolvePath} from '@loaders.gl/core';
 import {setLoaderOptions, fetchFile, parse, parseInBatches} from '@loaders.gl/core';
 
 // Small Arrow Sample Files
@@ -93,7 +93,7 @@ test('ArrowLoader#parseInBatches(Stream)', async t => {
   }
   const fs = require('fs');
   const stream = fs.createReadStream(resolvePath(ARROW_BIOGRID_NODES));
-  const asyncIterator = await parseInBatches(getStreamIterator(stream), ArrowLoader);
+  const asyncIterator = await parseInBatches(makeStreamIterator(stream), ArrowLoader);
   for await (const batch of asyncIterator) {
     t.ok(batch, 'received batch');
   }

--- a/modules/core/src/index.js
+++ b/modules/core/src/index.js
@@ -70,3 +70,7 @@ export {default as _fetchProgress} from './lib/progress/fetch-progress';
 
 // FOR TESTING
 export {_unregisterLoaders} from './lib/register-loaders';
+
+// DEPRECATED in v2.1
+export {concatenateChunksAsync as contatenateAsyncIterator} from './iterator-utils/chunk-iteration';
+export {makeStreamIterator as getStreamIterator} from './iterator-utils/stream-iteration';

--- a/modules/core/src/index.js
+++ b/modules/core/src/index.js
@@ -43,15 +43,16 @@ export {
 export {toArrayBuffer} from './javascript-utils/binary-utils';
 
 // ITERATOR UTILS
-export {getStreamIterator} from './javascript-utils/stream-utils';
+export {makeStreamIterator} from './iterator-utils/stream-iteration';
 
 export {
   forEach,
-  concatenateAsyncIterator,
   lineAsyncIterator,
   textDecoderAsyncIterator,
   numberedLineAsyncIterator
-} from './javascript-utils/async-iterator-utils';
+} from './iterator-utils/async-iteration';
+
+export {makeChunkIterator, concatenateChunksAsync} from './iterator-utils/chunk-iteration';
 
 // CORE UTILS SHARED WITH LOADERS (RE-EXPORTED FROM LOADER-UTILS)
 export {isBrowser, isWorker, self, window, global, document} from '@loaders.gl/loader-utils';

--- a/modules/core/src/iterator-utils/async-iteration.js
+++ b/modules/core/src/iterator-utils/async-iteration.js
@@ -1,14 +1,19 @@
 /* global TextDecoder, TextEncoder */
-import {concatenateArrayBuffers} from '../javascript-utils/memory-copy-utils';
 
 // GENERAL UTILITIES
 
-// Iterate over async iterator, without resetting iterator if end is not reached
-// - forEach does not reset iterator if exiting loop prematurely
-//   so that iteration can continue in a second loop
-// - It is recommended to use a standard for await as last loop to ensure
-//   iterator gets properly reset
-// TODO - optimize using sync iteration if argument is an Iterable?
+/**
+ * Iterate over async iterator, without resetting iterator if end is not reached
+ * - forEach intentionally does not reset iterator if exiting loop prematurely
+ *   so that iteration can continue in a second loop
+ * - It is recommended to use a standard for-await as last loop to ensure
+ *   iterator gets properly reset
+ *
+ * TODO - optimize using sync iteration if argument is an Iterable?
+ *
+ * @param iterator
+ * @param visitor
+ */
 export async function forEach(iterator, visitor) {
   // eslint-disable-next-line
   while (true) {
@@ -22,20 +27,6 @@ export async function forEach(iterator, visitor) {
       return;
     }
   }
-}
-
-// Concatenates all data chunks yielded by an async iterator
-export async function concatenateAsyncIterator(asyncIterator) {
-  let arrayBuffer = new ArrayBuffer();
-  let string = '';
-  for await (const chunk of asyncIterator) {
-    if (typeof chunk === 'string') {
-      string += chunk;
-    } else {
-      arrayBuffer = concatenateArrayBuffers(arrayBuffer, chunk);
-    }
-  }
-  return string || arrayBuffer;
 }
 
 // ITERATOR GENERATORS
@@ -64,9 +55,11 @@ export async function* textEncoderAsyncIterator(textIterator, options) {
   }
 }
 
-// Input: async iterable over strings
-// Returns: an async iterable over lines
-// See http://2ality.com/2018/04/async-iter-nodejs.html
+/**
+ * @param textIterator async iterable yielding strings
+ * @returns an async iterable over lines
+ * See http://2ality.com/2018/04/async-iter-nodejs.html
+ */
 
 export async function* lineAsyncIterator(textIterator) {
   let previous = '';
@@ -87,11 +80,11 @@ export async function* lineAsyncIterator(textIterator) {
 }
 
 /**
- * Parameter: async iterable of lines
- * Result: async iterable of numbered lines
+ * @param lineIterator async iterable yielding lines
+ * @returns async iterable yielding numbered lines
+ *
+ * See http://2ality.com/2018/04/async-iter-nodejs.html
  */
-// See http://2ality.com/2018/04/async-iter-nodejs.html
-// eslint-disable-next-line no-shadow
 export async function* numberedLineAsyncIterator(lineIterator) {
   let counter = 1;
   for await (const line of lineIterator) {

--- a/modules/core/src/iterator-utils/chunk-iteration.js
+++ b/modules/core/src/iterator-utils/chunk-iteration.js
@@ -3,8 +3,10 @@
 import {concatenateArrayBuffers} from '../javascript-utils/memory-copy-utils';
 
 /**
- * Concatenates all data chunks yielded by an async iterator
+ * Concatenates all data chunks yielded by an (async) iterator
  * Supports strings and ArrayBuffers
+ *
+ * This function can e.g. be used to enable atomic parsers to work on (async) iterator inputs
  */
 export async function concatenateChunksAsync(asyncIterator) {
   let arrayBuffer = new ArrayBuffer(0);
@@ -26,6 +28,9 @@ export async function concatenateChunksAsync(asyncIterator) {
  * @param options
  * @param options.chunkSize
  * @returns iterator that yields chunks of specified size
+ *
+ * This function can e.g. be used to enable data sources that can only be read atomically
+ * (such as `Blob` and `File` via `FileReader`) to still be parsed in batches.
  */
 export function* makeChunkIterator(bigArrayBufferOrString, options = {}) {
   if (typeof bigArrayBufferOrString === 'string') {
@@ -40,7 +45,7 @@ export function* makeChunkIterator(bigArrayBufferOrString, options = {}) {
 }
 
 /**
- * Breaks a big ArrayBuffer into chunks and returns an iterator that yields them one-by-one
+ * Helper: Breaks a big ArrayBuffer into chunks and returns an iterator that yields them one-by-one
  */
 function* makeArrayBufferChunkIterator(arrayBuffer, options = {}) {
   const {chunkSize = 256 * 1024} = options;
@@ -64,7 +69,7 @@ function* makeArrayBufferChunkIterator(arrayBuffer, options = {}) {
 }
 
 /**
- * Breaks a big string into chunks and returns an iterator that yields them one-by-one
+ * Helper: Breaks a big string into chunks and returns an iterator that yields them one-by-one
  */
 function* makeStringChunkIterator(string, options = {}) {
   const {chunkSize = 256 * 1024} = options;

--- a/modules/core/src/iterator-utils/chunk-iteration.js
+++ b/modules/core/src/iterator-utils/chunk-iteration.js
@@ -1,0 +1,83 @@
+// Breaking big data into iterable chunks, concatenating iterable chunks into big data objects
+
+import {concatenateArrayBuffers} from '../javascript-utils/memory-copy-utils';
+
+/**
+ * Concatenates all data chunks yielded by an async iterator
+ * Supports strings and ArrayBuffers
+ */
+export async function concatenateChunksAsync(asyncIterator) {
+  let arrayBuffer = new ArrayBuffer(0);
+  let string = '';
+  for await (const chunk of asyncIterator) {
+    if (typeof chunk === 'string') {
+      string += chunk;
+    } else {
+      arrayBuffer = concatenateArrayBuffers(arrayBuffer, chunk);
+    }
+  }
+  return string || arrayBuffer;
+}
+
+/**
+ * Returns an iterator that breaks a big `ArrayBuffer` or string into chunks and yields them one-by-one.
+ *
+ * @param bigArrayBufferOrString
+ * @param options
+ * @param options.chunkSize
+ * @returns iterator that yields chunks of specified size
+ */
+export function* makeChunkIterator(bigArrayBufferOrString, options = {}) {
+  if (typeof bigArrayBufferOrString === 'string') {
+    yield* makeStringChunkIterator(bigArrayBufferOrString, options);
+    return;
+  }
+  if (bigArrayBufferOrString instanceof ArrayBuffer) {
+    yield* makeArrayBufferChunkIterator(bigArrayBufferOrString, options);
+    return;
+  }
+  throw new Error('assert');
+}
+
+/**
+ * Breaks a big ArrayBuffer into chunks and returns an iterator that yields them one-by-one
+ */
+function* makeArrayBufferChunkIterator(arrayBuffer, options = {}) {
+  const {chunkSize = 256 * 1024} = options;
+
+  let byteOffset = 0;
+
+  while (byteOffset < arrayBuffer.byteLength) {
+    // Create a chunk of the right size
+    const chunkByteLength = Math.min(arrayBuffer.byteLength - byteOffset, chunkSize);
+    const chunk = new ArrayBuffer(chunkByteLength);
+
+    // Copy data from the big chunk
+    const sourceArray = new Uint8Array(arrayBuffer, byteOffset, chunkByteLength);
+    const chunkArray = new Uint8Array(chunk);
+    chunkArray.set(sourceArray);
+
+    // yield the chunk
+    byteOffset += chunkByteLength;
+    yield chunk;
+  }
+}
+
+/**
+ * Breaks a big string into chunks and returns an iterator that yields them one-by-one
+ */
+function* makeStringChunkIterator(string, options = {}) {
+  const {chunkSize = 256 * 1024} = options;
+
+  let offset = 0;
+
+  while (offset < string.length) {
+    // Create a chunk of the right size
+    const chunkLength = Math.min(string.length - offset, chunkSize);
+    const chunk = string.slice(offset, offset + chunkLength);
+    offset += chunkLength;
+
+    // yield the chunk
+    yield chunk;
+  }
+}

--- a/modules/core/src/iterator-utils/stream-iteration.js
+++ b/modules/core/src/iterator-utils/stream-iteration.js
@@ -1,6 +1,6 @@
 import {isBrowser, nodeVersion} from '@loaders.gl/loader-utils';
 
-export function getStreamIterator(stream) {
+export function makeStreamIterator(stream) {
   // Hacky test for node version to ensure we don't call bad polyfills
   if (isBrowser || nodeVersion >= 10) {
     // NODE 10+: stream is an asyncIterator

--- a/modules/core/src/lib/loader-utils/get-data.js
+++ b/modules/core/src/lib/loader-utils/get-data.js
@@ -8,8 +8,8 @@ import {
   isFileReadable,
   isBuffer
 } from '../../javascript-utils/is-type';
-import {getStreamIterator} from '../../javascript-utils/stream-utils';
-import {concatenateAsyncIterator} from '../../javascript-utils/async-iterator-utils';
+import {makeStreamIterator} from '../../iterator-utils/stream-iteration';
+import {concatenateChunksAsync} from '../../iterator-utils/chunk-iteration';
 import fetchFileReadable from '../fetch/fetch-file.browser';
 import {checkFetchResponseStatus, checkFetchResponseStatusSync} from './check-errors';
 
@@ -89,12 +89,12 @@ export async function getArrayBufferOrStringFromData(data, loader) {
   }
 
   if (isReadableStream(data)) {
-    data = getStreamIterator(data);
+    data = makeStreamIterator(data);
   }
 
   if (isIterable(data) || isAsyncIterable(data)) {
     // Assume arrayBuffer iterator - attempt to concatenate
-    return concatenateAsyncIterator(data);
+    return concatenateChunksAsync(data);
   }
 
   throw new Error(ERR_DATA);
@@ -109,11 +109,11 @@ export function getAsyncIteratorFromData(data) {
   if (isFetchResponse(data) && data.body) {
     // Note Since this function is not async, we currently can't load error message, just status
     checkFetchResponseStatusSync(data);
-    return getStreamIterator(data.body);
+    return makeStreamIterator(data.body);
   }
 
   if (isReadableStream(data)) {
-    return getStreamIterator(data);
+    return makeStreamIterator(data);
   }
 
   if (isAsyncIterable(data)) {

--- a/modules/core/src/lib/parse-in-batches.js
+++ b/modules/core/src/lib/parse-in-batches.js
@@ -3,7 +3,7 @@ import {mergeOptions} from './loader-utils/merge-options';
 import {getAsyncIteratorFromData} from './loader-utils/get-data';
 import {getLoaderContext} from './loader-utils/get-loader-context';
 import {selectLoader} from './select-loader';
-import {textDecoderAsyncIterator} from '../javascript-utils/async-iterator-utils';
+import {textDecoderAsyncIterator} from '../iterator-utils/async-iteration';
 
 export async function parseInBatches(data, loaders, options, url) {
   // Signature: parseInBatches(data, options, url)

--- a/modules/core/test/index.js
+++ b/modules/core/test/index.js
@@ -1,4 +1,10 @@
-import './javascript-utils';
+import './javascript-utils/text-encoder.spec';
+import './javascript-utils/binary-utils.spec';
+import './javascript-utils/is-type.spec';
+
+import './iterator-utils/chunk-iteration.spec';
+import './iterator-utils/async-iteration.spec';
+import './iterator-utils/stream-iteration.spec';
 
 import './lib/fetch';
 import './lib/loader-utils';

--- a/modules/core/test/iterator-utils/async-iteration.spec.js
+++ b/modules/core/test/iterator-utils/async-iteration.spec.js
@@ -3,12 +3,11 @@ import test from 'tape-promise/tape';
 
 import {
   forEach,
-  concatenateAsyncIterator,
   lineAsyncIterator,
   textDecoderAsyncIterator,
   textEncoderAsyncIterator,
   numberedLineAsyncIterator
-} from '@loaders.gl/core/javascript-utils/async-iterator-utils';
+} from '@loaders.gl/core/iterator-utils/async-iteration';
 
 /* global setTimeout */
 const setTimeoutPromise = timeout => new Promise(resolve => setTimeout(resolve, timeout));
@@ -43,20 +42,6 @@ test('async-iterator#forEach', async t => {
     iterations++;
     t.is(number, iterations, `async iterating over ${number}`);
   });
-});
-
-test('async-iterator#concatenateAsyncIterator', async t => {
-  const RESULT = `line 1\nline 2\nline 3\nline 4`;
-
-  const text = await concatenateAsyncIterator(asyncTexts());
-  t.is(text, RESULT, 'returns concatenated string');
-
-  const arraybuffer = await concatenateAsyncIterator(asyncArrayBuffers());
-  t.ok(arraybuffer instanceof Uint8Array, 'returns buffer');
-  /* global TextEncoder */
-  t.deepEqual(arraybuffer, new TextEncoder().encode(RESULT), 'returns concatenated arraybuffer');
-
-  t.end();
 });
 
 test('async-iterator#textDecoderAsyncIterator', async t => {

--- a/modules/core/test/iterator-utils/chunk-iteration.spec.js
+++ b/modules/core/test/iterator-utils/chunk-iteration.spec.js
@@ -1,0 +1,63 @@
+import test from 'tape-promise/tape';
+
+import {
+  makeChunkIterator,
+  concatenateChunksAsync
+} from '@loaders.gl/core/iterator-utils/chunk-iteration';
+import {textEncoderAsyncIterator} from '@loaders.gl/core/iterator-utils/async-iteration';
+
+/* global setTimeout */
+const setTimeoutPromise = timeout => new Promise(resolve => setTimeout(resolve, timeout));
+
+async function* asyncTexts() {
+  await setTimeoutPromise(10);
+  yield 'line 1\nline';
+  await setTimeoutPromise(10);
+  yield ' 2\nline 3\n';
+  await setTimeoutPromise(10);
+  yield 'line 4';
+}
+
+function asyncArrayBuffers() {
+  return textEncoderAsyncIterator(asyncTexts());
+}
+
+test('concatenateChunksAsync', async t => {
+  const RESULT = `line 1\nline 2\nline 3\nline 4`;
+
+  const text = await concatenateChunksAsync(asyncTexts());
+  t.is(text, RESULT, 'returns concatenated string');
+
+  const arraybuffer = await concatenateChunksAsync(asyncArrayBuffers());
+  t.ok(arraybuffer instanceof Uint8Array, 'returns buffer');
+  /* global TextEncoder */
+  t.deepEqual(arraybuffer, new TextEncoder().encode(RESULT), 'returns concatenated arraybuffer');
+
+  t.end();
+});
+
+test('makeChunkIterator#string', async t => {
+  const bigString = '123456';
+  const results = ['12', '34', '56'];
+
+  const iterator = makeChunkIterator(bigString, {chunkSize: 2});
+
+  for (const chunk of iterator) {
+    t.equal(chunk, results.shift());
+  }
+
+  t.end();
+});
+
+test('makeChunkIterator#arrayBuffer', async t => {
+  const bigString = new ArrayBuffer(6);
+
+  const iterator = makeChunkIterator(bigString, {chunkSize: 2});
+
+  for (const chunk of iterator) {
+    t.ok(chunk instanceof ArrayBuffer);
+    t.equal(chunk.byteLength, 2);
+  }
+
+  t.end();
+});

--- a/modules/core/test/iterator-utils/stream-iteration.spec.js
+++ b/modules/core/test/iterator-utils/stream-iteration.spec.js
@@ -1,14 +1,14 @@
 import test from 'tape-promise/tape';
-import {fetchFile, getStreamIterator} from '@loaders.gl/core';
+import {fetchFile, makeStreamIterator} from '@loaders.gl/core';
 
 const DATA_URL = '@loaders.gl/draco/test/data/raw-attribute-buffers/lidar-positions.bin';
 
-test('getStreamIterator(fetch)#async iterate', async t => {
+test('makeStreamIterator(fetch)#async iterate', async t => {
   const response = await fetchFile(DATA_URL);
   const stream = await response.body;
   t.ok(stream);
 
-  const asyncIterator = getStreamIterator(stream);
+  const asyncIterator = makeStreamIterator(stream);
   t.ok(asyncIterator);
 
   for await (const arrayBuffer of asyncIterator) {

--- a/modules/core/test/javascript-utils/index.js
+++ b/modules/core/test/javascript-utils/index.js
@@ -1,5 +1,0 @@
-import './async-iterator.spec';
-import './text-encoder.spec';
-import './binary-utils.spec';
-import './is-type.spec';
-import './stream-iterator.spec';

--- a/modules/json/test/lib/parser/streaming-json-parser.spec.js
+++ b/modules/json/test/lib/parser/streaming-json-parser.spec.js
@@ -1,6 +1,6 @@
 /* global TextDecoder */
 import test from 'tape-promise/tape';
-import {fetchFile, getStreamIterator} from '@loaders.gl/core';
+import {fetchFile, makeStreamIterator} from '@loaders.gl/core';
 import StreamingJSONParser from '@loaders.gl/json/lib/parser/streaming-json-parser';
 
 const GEOJSON_PATH = `@loaders.gl/json/test/data/geojson-big.json`;
@@ -10,7 +10,7 @@ test('StreamingJSONParser#geojson', async t => {
 
   // Can return text stream by setting `{encoding: 'utf8'}`, but only works on Node
   const response = await fetchFile(GEOJSON_PATH, {highWaterMark: 16384});
-  for await (const chunk of getStreamIterator(response.body)) {
+  for await (const chunk of makeStreamIterator(response.body)) {
     const string = new TextDecoder().decode(chunk);
     parser.write(string);
   }

--- a/modules/ply/test/ply-loader.bench.js
+++ b/modules/ply/test/ply-loader.bench.js
@@ -1,4 +1,4 @@
-import {fetchFile, load, createReadStream, getStreamIterator} from '@loaders.gl/core';
+import {fetchFile, load, createReadStream, makeStreamIterator} from '@loaders.gl/core';
 import {PLYLoader, PLYWorkerLoader, _PLYStreamLoader} from '@loaders.gl/ply';
 
 export default function PLYLoaderBench(bench) {
@@ -19,7 +19,7 @@ export default function PLYLoaderBench(bench) {
       })
       .addAsync('Stream parsing', async () => {
         const stream = await createReadStream('@loaders.gl/ply/test/data/cube_att.ply');
-        await _PLYStreamLoader.parseStream(getStreamIterator(stream));
+        await _PLYStreamLoader.parseStream(makeStreamIterator(stream));
       })
 
       .group('PLYLoader (Binary)')

--- a/modules/ply/test/ply-loader.spec.js
+++ b/modules/ply/test/ply-loader.spec.js
@@ -4,7 +4,7 @@ import {validateLoader, validatePointCloudCategoryData} from 'test/common/confor
 
 import {PLYLoader, PLYWorkerLoader, _PLYStreamLoader} from '@loaders.gl/ply';
 import {setLoaderOptions, fetchFile, parse, parseSync, load} from '@loaders.gl/core';
-import {getStreamIterator} from '@loaders.gl/core';
+import {makeStreamIterator} from '@loaders.gl/core';
 
 const PLY_CUBE_ATT_URL = '@loaders.gl/ply/test/data/cube_att.ply';
 const PLY_BUN_ZIPPER_URL = '@loaders.gl/ply/test/data/bun_zipper.ply';
@@ -80,7 +80,7 @@ test('PLYLoader#parseStream(text)', async t => {
   const response = await fetchFile(PLY_CUBE_ATT_URL);
   const stream = await response.body;
 
-  const data = await _PLYStreamLoader.parseStream(getStreamIterator(stream));
+  const data = await _PLYStreamLoader.parseStream(makeStreamIterator(stream));
 
   validatePointCloudCategoryData(t, data);
   t.equal(data.indices.value.length, 36, 'Indices found');

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "eslint-plugin-react": "^7.13",
     "gl": "^4.4.0",
     "gl-matrix": "^3.1.0",
-    "ocular-dev-tools": "^0.1.5",
+    "ocular-dev-tools": "^0.1.8",
     "pre-commit": "^1.2.2",
     "pre-push": "^0.1.1",
     "reify": "^0.19.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7114,10 +7114,10 @@ octokit-pagination-methods@^1.1.0:
   resolved "https://registry.yarnpkg.com/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz#cf472edc9d551055f9ef73f6e42b4dbb4c80bea4"
   integrity sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ==
 
-ocular-dev-tools@^0.1.5:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/ocular-dev-tools/-/ocular-dev-tools-0.1.5.tgz#17986a8440689c1375e404318123b6a2adfff261"
-  integrity sha512-lFR+0CtH/lEicsyRosNUuOh+1bZdW+uCshoxaUz5WHSsO2qHBi6qrboHYTOA2EFn+jUwcEcrtDGHJEGh7xl1hA==
+ocular-dev-tools@^0.1.8:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/ocular-dev-tools/-/ocular-dev-tools-0.1.8.tgz#da026de73fbe4e7aab1dc31339a5d83cf3c91839"
+  integrity sha512-ax/FXpqi9PtP1hzTdd+GlzTwscaChZdu7T/hqcHTvnCZf4PZluRuH/obIt+Ln31xl6eS2roCDt1pOsv5MSD70A==
   dependencies:
     "@babel/cli" "^7.0.0"
     "@babel/core" "^7.0.0"


### PR DESCRIPTION
This function will be used to implement `parseInBatches` for `File` objects.

The goal here is to enable kepler.gl to use loaders.gl, and having streaming parsing support for `File` objects is a key goal.