### PR TITLE
images: additional bitmap checks

### DIFF
--- a/modules/images/src/lib/binary-image-api/binary-image-parsers.js
+++ b/modules/images/src/lib/binary-image-api/binary-image-parsers.js
@@ -45,7 +45,12 @@ function getGifSize(dataView) {
 // TODO: BMP is not this simple
 export function isBmp(dataView) {
   // Check magic number is valid (first 2 characters should be "BM").
-  return dataView.byteLength >= 2 && dataView.getUint16(0, BIG_ENDIAN) === 0x424d;
+  // The mandatory bitmap file header is 14 bytes long.
+  return (
+    dataView.byteLength >= 14 &&
+    dataView.getUint16(0, BIG_ENDIAN) === 0x424d &&
+    dataView.getUint32(2, LITTLE_ENDIAN) === dataView.byteLength
+  );
 }
 
 function getBmpSize(dataView) {

--- a/modules/images/test/lib/binary-image-api.spec.js
+++ b/modules/images/test/lib/binary-image-api.spec.js
@@ -29,6 +29,20 @@ test('isBinaryImage', async t => {
   t.end();
 });
 
+test('isBinaryImage#bmp detection edge case', t => {
+  const arrayBuffer = new ArrayBuffer(4);
+  const dataView = new DataView(arrayBuffer);
+  const LITTLE_ENDIAN = true;
+
+  // Encodes as 0x424D3EC4 and when written as little endian stored as 0xC4 0x3E 0x4D 0x42,
+  // which matches BMP's magic characters.
+  dataView.setFloat32(0, -761.207153, LITTLE_ENDIAN);
+
+  t.equals(dataView.getUint16(0, LITTLE_ENDIAN), 0x4d42, 'Test data written correctly');
+  t.notOk(isBinaryImage(arrayBuffer, 'image/bmp'));
+  t.end();
+});
+
 test('isBinaryImage#jpeg detection edge case', async t => {
   const arrayBuffer = new ArrayBuffer(4);
   const dataView = new DataView(arrayBuffer);


### PR DESCRIPTION
Add few additional bitmap file checks to prevent false positives:
- the header is at least 14 bytes long [wikipedia](https://en.wikipedia.org/wiki/BMP_file_format#File_structure)
- bytes 2-6 contain the size of the bitmap (incl header) [wikipedia](https://en.wikipedia.org/wiki/BMP_file_format#Bitmap_file_header)