### PR TITLE
images: additional jpeg check

### DIFF
--- a/modules/images/src/lib/binary-image-api/binary-image-parsers.js
+++ b/modules/images/src/lib/binary-image-api/binary-image-parsers.js
@@ -64,7 +64,8 @@ export function isJpeg(dataView) {
   return (
     dataView.byteLength >= 3 &&
     dataView.getUint16(0, BIG_ENDIAN) === 0xffd8 &&
-    dataView.getUint8(2, BIG_ENDIAN) === 0xff
+    dataView.getUint8(2, BIG_ENDIAN) === 0xff &&
+    dataView.getUint16(dataView.byteLength - 2, BIG_ENDIAN) === 0xffd9
   );
 }
 

--- a/modules/images/test/lib/binary-image-api.spec.js
+++ b/modules/images/test/lib/binary-image-api.spec.js
@@ -45,12 +45,21 @@ test('isBinaryImage#jpeg detection edge case', async t => {
 
   // Encodes as 0xC2FFD8FF and when written as little endian stored // as 0xFF 0xD8 0xFF 0xC2
   dataView.setFloat32(0, -127.92382049560547, LITTLE_ENDIAN);
+
   t.equals(dataView.getUint32(0), 0xffd8ffc2, 'Test data written correctly');
+  t.notOk(
+    isBinaryImage(arrayBuffer),
+    'isBinaryImage fails with floating point data matching first 3 bytes of jpeg magic'
+  );
+
+  // Encodes as 0xD9FFD8FF and when written as little endian stored // as 0xFF 0xD8 0xFF 0xD9
+  dataView.setUint32(0, 3657423103, LITTLE_ENDIAN);
+  t.equals(dataView.getUint32(0), 0xffd8ffd9, 'Test data written correctly');
 
   // False positive case!
   t.ok(
     isBinaryImage(arrayBuffer),
-    'isBinaryImage has a false positive with floating point data matching first 3 bytes of jpeg magic'
+    'isBinaryImage has a false positive with floating point data matching first 3 and last 2 bytes of jpeg magic'
   );
 
   t.end();


### PR DESCRIPTION
As an additional safeguard for false positives, check the end of image marker [wikipedia](https://en.wikipedia.org/wiki/JPEG_File_Interchange_Format#File_format_structure).