### PR TITLE
basis: disable CDN when running local test

### DIFF
--- a/modules/basis/src/basis-loader.js
+++ b/modules/basis/src/basis-loader.js
@@ -17,8 +17,8 @@ export const BasisWorkerLoader = {
   options: {
     basis: {
       format: 'rgb565', // TODO: auto...
-      libraryPath: `libs/`
-      // workerUrl: `https://unpkg.com/@loaders.gl/basis@${VERSION}/dist/basis-loader.worker.js`
+      libraryPath: `libs/`,
+      workerUrl: `https://unpkg.com/@loaders.gl/basis@${VERSION}/dist/basis-loader.worker.js`
     }
   }
 };

--- a/modules/basis/test/basis-loader.spec.js
+++ b/modules/basis/test/basis-loader.spec.js
@@ -1,9 +1,16 @@
 import test from 'tape-promise/tape';
 
 import {BasisLoader} from '@loaders.gl/basis';
-import {load} from '@loaders.gl/core';
+import {load, setLoaderOptions} from '@loaders.gl/core';
 
 const TEST_URL = '@loaders.gl/basis/test/data/alpha3.basis';
+
+setLoaderOptions({
+  CDN: null,
+  basis: {
+    workerUrl: 'modules/basis/dist/basis-loader.worker.js'
+  }
+});
 
 test('BasisLoader#imports', t => {
   t.ok(BasisLoader, 'BasisLoader defined');


### PR DESCRIPTION
Problem:

When running browser tests locally, [`basis`](https://github.com/uber-web/loaders.gl/blob/master/modules/basis/src/lib/basis-module-loader.js#L19) module will try to [load from CDN](https://github.com/uber-web/loaders.gl/blob/master/modules/loader-utils/src/lib/library-utils/library-utils.js#L48). 
