### PR TITLE
GeoJSON to binary arrays improvements

### DIFF
--- a/modules/gis/docs/api-reference/geojson-to-binary.md
+++ b/modules/gis/docs/api-reference/geojson-to-binary.md
@@ -19,51 +19,92 @@ const geoJSONfeatures = await load(url, MVTLoader, loaderOptions);
 * Default options are:
 *
 * {
+*   coordLength: derived from data
+*   numericPropKeys: derived from data
 *   PositionDataType: Float32Array
 * }
 */
+const options = {PositionDataType: Float32Array};
 const binaryArrays = geojsonToBinary(geoJSONfeatures, options);
 ```
 
 ## Outputs
 
-### TypedArrays
-
 `geojsonToBinary` returns an object containing typed arrays sorted by geometry
-type. `positions` corresponds to 2D or 3D coordinates; `objectIds` returns the
-index of the vertex in the initial `features` array.
+type. `positions` is a flat array of coordinates; `globalFeatureIds` references
+indices in the original `features` array; `featureIds` references feature
+indices of the same geometry type; `numericProps` contains `TypedArray`s
+generated from numeric feature properties; `properties` is an array of
+non-numeric property objects of the given geometry type.
+
+Each `TypedArray` is wrapped inside an _accessor object_, where `.value` contains the raw numeric data, and `.size` gives the number of values per vertex. For example,
+
+```js
+positions: {value: Float32Array, size: 3}
+```
+
+corresponds to 3D coordinates, where each vertex is defined by three numbers.
 
 ```js
 {
   points: {
     // Array of x, y or x, y, z positions
-    positions: {value: Float32Array, size: coordLength},
+    positions: {value: PositionDataType, size: coordLength},
     // Array of original feature indexes by vertex
-    objectIds: {value: Uint32Array, size: 1},
+    globalFeatureIds: {value: Uint16Array || Uint32Array, size: 1},
+    // Array of Point feature indexes by vertex
+    featureIds: {value: Uint16Array || Uint32Array, size: 1},
+    // Object with accessor objects for numeric properties
+    // Numeric properties are sized to have one value per vertex
+    numericProps: {
+        numericProperty1: {value: Float32Array, size: 1}
+    }
+    // Array of objects with non-numeric properties from Point geometries
+    properties: [{PointFeatureProperties}]
   },
   lines: {
-    // Indices within positions of the start of each individual LineString
-    pathIndices: {value: Uint32Array, size: 1},
     // Array of x, y or x, y, z positions
-    positions: {value: Float32Array, size: coordLength},
+    positions: {value: PositionDataType, size: coordLength},
+    // Indices within positions of the start of each individual LineString
+    pathIndices: {value: Uint16Array || Uint32Array, size: 1},
     // Array of original feature indexes by vertex
-    objectIds: {value: Uint32Array, size: 1},
+    globalFeatureIds: {value: Uint16Array || Uint32Array, size: 1},
+    // Array of LineString feature indexes by vertex
+    featureIds: {value: Uint16Array || Uint32Array, size: 1},
+    // Object with accessor objects for numeric properties
+    // Numeric properties are sized to have one value per vertex
+    numericProps: {
+        numericProperty1: {value: Float32Array, size: 1}
+    }
+    // Array of objects with non-numeric properties from LineString geometries
+    properties: [{LineStringFeatureProperties}]
   },
   polygons: {
-    // Indices within positions of the start of each complex Polygon
-    polygonIndices: {value: Uint32Array, size: 1},
-    // Indices within positions of the start of each primitive Polygon/ring
-    primitivePolygonIndices: {value: Uint32Array, size: 1},
     // Array of x, y or x, y, z positions
-    positions: {value: Float32Array, size: coordLength},
+    positions: {value: PositionDataType, size: coordLength},
+    // Indices within positions of the start of each complex Polygon
+    polygonIndices: {value: Uint16Array || Uint32Array, size: 1},
+    // Indices within positions of the start of each primitive Polygon/ring
+    primitivePolygonIndices: {value: Uint16Array || Uint32Array, size: 1},
     // Array of original feature indexes by vertex
-    objectIds: {value: Uint32Array, size: 1},
+    globalFeatureIds: {value: Uint16Array || Uint32Array, size: 1},
+    // Array of Polygon feature indexes by vertex
+    featureIds: {value: Uint16Array || Uint32Array, size: 1},
+    // Object with accessor objects for numeric properties
+    // Numeric properties are sized to have one value per vertex
+    numericProps: {
+        numericProperty1: {value: Float32Array, size: 1}
+    }
+    // Array of objects with non-numeric properties from Polygon geometries
+    properties: [{PolygonFeatureProperties}]
   }
 }
 ```
 
 ## Options
 
-| Option           | Type                             | Default        | Description                         |
-| ---------------- | -------------------------------- | -------------- | ----------------------------------- |
-| PositionDataType | `Float32Array` or `Float64Array` | `Float32Array` | Data type used for positions arrays |
+| Option           | Type     | Default           | Description                                                                                                                                             |
+| ---------------- | -------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| PositionDataType | `class`  | `Float32Array`    | Data type used for positions arrays.                                                                                                                    |
+| numericPropKeys  | `Array`  | Derived from data | Names of feature properties that should be converted to numeric `TypedArray`s. Passing `[]` will force all properties to be returned as normal objects. |
+| coordLength      | `number` | Derived from data | Number of dimensions per coordinate.                                                                                                                    |

--- a/modules/gis/src/index.js
+++ b/modules/gis/src/index.js
@@ -1,1 +1,1 @@
-export {geojsonToBinary} from './lib/geojson-to-binary';
+export {geojsonToBinary, TEST_EXPORTS} from './lib/geojson-to-binary';

--- a/modules/gis/src/lib/geojson-to-binary.js
+++ b/modules/gis/src/lib/geojson-to-binary.js
@@ -16,7 +16,7 @@ function firstPass(features) {
   let polygonPositions = 0;
   let polygonObjects = 0;
   let polygonRings = 0;
-  let maxCoordLength = 2;
+  const coordLengths = new Set();
   const numericProps = {};
 
   for (const feature of features) {
@@ -24,15 +24,12 @@ function firstPass(features) {
     switch (geometry.type) {
       case 'Point':
         pointPositions++;
-        if (geometry.coordinates.length === 3) {
-          maxCoordLength = 3;
-        }
+        coordLengths.add(geometry.coordinates.length);
         break;
       case 'MultiPoint':
         pointPositions += geometry.coordinates.length;
         for (const point of geometry.coordinates) {
-          // eslint-disable-next-line max-depth
-          if (point.length === 3) maxCoordLength = 3;
+          coordLengths.add(point.length);
         }
         break;
       case 'LineString':
@@ -40,8 +37,7 @@ function firstPass(features) {
         linePaths++;
 
         for (const coord of geometry.coordinates) {
-          // eslint-disable-next-line max-depth
-          if (coord.length === 3) maxCoordLength = 3;
+          coordLengths.add(coord.length);
         }
         break;
       case 'MultiLineString':
@@ -51,8 +47,7 @@ function firstPass(features) {
 
           // eslint-disable-next-line max-depth
           for (const coord of line) {
-            // eslint-disable-next-line max-depth
-            if (coord.length === 3) maxCoordLength = 3;
+            coordLengths.add(coord.length);
           }
         }
         break;
@@ -62,8 +57,7 @@ function firstPass(features) {
         polygonPositions += flatten(geometry.coordinates).length;
 
         for (const coord of flatten(geometry.coordinates)) {
-          // eslint-disable-next-line max-depth
-          if (coord.length === 3) maxCoordLength = 3;
+          coordLengths.add(coord.length);
         }
         break;
       case 'MultiPolygon':
@@ -74,8 +68,7 @@ function firstPass(features) {
 
           // eslint-disable-next-line max-depth
           for (const coord of flatten(polygon)) {
-            // eslint-disable-next-line max-depth
-            if (coord.length === 3) maxCoordLength = 3;
+            coordLengths.add(coord.length);
           }
         }
         break;
@@ -95,7 +88,7 @@ function firstPass(features) {
     pointPositions,
     linePositions,
     linePaths,
-    coordLength: maxCoordLength,
+    coordLength: Math.max(...coordLengths),
     polygonPositions,
     polygonObjects,
     polygonRings,

--- a/modules/gis/src/lib/geojson-to-binary.js
+++ b/modules/gis/src/lib/geojson-to-binary.js
@@ -120,24 +120,27 @@ function secondPass(features, firstPassData, options = {}) {
   const {PositionDataType = Float32Array} = options;
   const points = {
     positions: new PositionDataType(pointPositions * coordLength),
-    objectIds: new Uint32Array(pointPositions)
+    objectIds: new Uint32Array(pointPositions),
+    numericProps: {}
   };
   const lines = {
     pathIndices: new Uint32Array(linePaths + 1),
     positions: new PositionDataType(linePositions * coordLength),
-    objectIds: new Uint32Array(linePositions)
+    objectIds: new Uint32Array(linePositions),
+    numericProps: {}
   };
   const polygons = {
     polygonIndices: new Uint32Array(polygonObjects + 1),
     primitivePolygonIndices: new Uint32Array(polygonRings + 1),
     positions: new PositionDataType(polygonPositions * coordLength),
-    objectIds: new Uint32Array(polygonPositions)
+    objectIds: new Uint32Array(polygonPositions),
+    numericProps: {}
   };
 
   // Instantiate numeric properties arrays; one value per vertex
   for (const object of [points, lines, polygons]) {
     for (const propName of numericProps) {
-      object[propName] = new Float32Array(object.positions.length / coordLength);
+      object.numericProps[propName] = new Float32Array(object.positions.length / coordLength);
     }
   }
   // Set last element of path/polygon indices as positions length

--- a/modules/gis/src/lib/geojson-to-binary.js
+++ b/modules/gis/src/lib/geojson-to-binary.js
@@ -129,11 +129,11 @@ function secondPass(features, firstPassData = {}, options = {}) {
     polygonFeaturesCount
   } = firstPassData;
   const {coordLength, numericPropKeys, PositionDataType = Float32Array} = options;
-  const GlobalFeatureIndexDataType = features.length > 65535 ? Uint32Array : Uint16Array;
+  const GlobalFeatureIdsDataType = features.length > 65535 ? Uint32Array : Uint16Array;
   const points = {
     positions: new PositionDataType(pointPositionsCount * coordLength),
-    globalFeatureIndex: new GlobalFeatureIndexDataType(pointPositionsCount),
-    featureIndex:
+    globalFeatureIds: new GlobalFeatureIdsDataType(pointPositionsCount),
+    featureIds:
       pointFeaturesCount > 65535
         ? new Uint32Array(pointPositionsCount)
         : new Uint16Array(pointPositionsCount),
@@ -146,8 +146,8 @@ function secondPass(features, firstPassData = {}, options = {}) {
         ? new Uint32Array(linePathsCount + 1)
         : new Uint16Array(linePathsCount + 1),
     positions: new PositionDataType(linePositionsCount * coordLength),
-    globalFeatureIndex: new GlobalFeatureIndexDataType(linePositionsCount),
-    featureIndex:
+    globalFeatureIds: new GlobalFeatureIdsDataType(linePositionsCount),
+    featureIds:
       lineFeaturesCount > 65535
         ? new Uint32Array(linePositionsCount)
         : new Uint16Array(linePositionsCount),
@@ -164,8 +164,8 @@ function secondPass(features, firstPassData = {}, options = {}) {
         ? new Uint32Array(polygonRingsCount + 1)
         : new Uint16Array(polygonRingsCount + 1),
     positions: new PositionDataType(polygonPositionsCount * coordLength),
-    globalFeatureIndex: new GlobalFeatureIndexDataType(polygonPositionsCount),
-    featureIndex:
+    globalFeatureIds: new GlobalFeatureIdsDataType(polygonPositionsCount),
+    featureIds:
       polygonFeaturesCount > 65535
         ? new Uint32Array(polygonPositionsCount)
         : new Uint16Array(polygonPositionsCount),
@@ -249,8 +249,8 @@ function secondPass(features, firstPassData = {}, options = {}) {
 // Fills Point coordinates into points object of arrays
 function handlePoint(coords, points, indexMap, coordLength, properties) {
   points.positions.set(coords, indexMap.pointPosition * coordLength);
-  points.globalFeatureIndex[indexMap.pointPosition] = indexMap.feature;
-  points.featureIndex[indexMap.pointPosition] = indexMap.pointFeature;
+  points.globalFeatureIds[indexMap.pointPosition] = indexMap.feature;
+  points.featureIds[indexMap.pointPosition] = indexMap.pointFeature;
 
   fillNumericProperties(points, properties, indexMap.pointPosition, 1);
   indexMap.pointPosition++;
@@ -273,11 +273,11 @@ function handleLineString(coords, lines, indexMap, coordLength, properties) {
   const nPositions = coords.length;
   fillNumericProperties(lines, properties, indexMap.linePosition, nPositions);
 
-  lines.globalFeatureIndex.set(
+  lines.globalFeatureIds.set(
     new Uint32Array(nPositions).fill(indexMap.feature),
     indexMap.linePosition
   );
-  lines.featureIndex.set(
+  lines.featureIds.set(
     new Uint32Array(nPositions).fill(indexMap.lineFeature),
     indexMap.linePosition
   );
@@ -305,11 +305,11 @@ function handlePolygon(coords, polygons, indexMap, coordLength, properties) {
     const nPositions = ring.length;
     fillNumericProperties(polygons, properties, indexMap.polygonPosition, nPositions);
 
-    polygons.globalFeatureIndex.set(
+    polygons.globalFeatureIds.set(
       new Uint32Array(nPositions).fill(indexMap.feature),
       indexMap.polygonPosition
     );
-    polygons.featureIndex.set(
+    polygons.featureIds.set(
       new Uint32Array(nPositions).fill(indexMap.polygonFeature),
       indexMap.polygonPosition
     );
@@ -329,16 +329,16 @@ function makeAccessorObjects(points, lines, polygons, coordLength) {
   const returnObj = {
     points: {
       positions: {value: points.positions, size: coordLength},
-      globalFeatureIndex: {value: points.globalFeatureIndex, size: 1},
-      featureIndex: {value: points.featureIndex, size: 1},
+      globalFeatureIds: {value: points.globalFeatureIds, size: 1},
+      featureIds: {value: points.featureIds, size: 1},
       numericProps: points.numericProps,
       properties: points.properties
     },
     lines: {
       pathIndices: {value: lines.pathIndices, size: 1},
       positions: {value: lines.positions, size: coordLength},
-      globalFeatureIndex: {value: lines.globalFeatureIndex, size: 1},
-      featureIndex: {value: lines.featureIndex, size: 1},
+      globalFeatureIds: {value: lines.globalFeatureIds, size: 1},
+      featureIds: {value: lines.featureIds, size: 1},
       numericProps: lines.numericProps,
       properties: lines.properties
     },
@@ -346,8 +346,8 @@ function makeAccessorObjects(points, lines, polygons, coordLength) {
       polygonIndices: {value: polygons.polygonIndices, size: 1},
       primitivePolygonIndices: {value: polygons.primitivePolygonIndices, size: 1},
       positions: {value: polygons.positions, size: coordLength},
-      globalFeatureIndex: {value: polygons.globalFeatureIndex, size: 1},
-      featureIndex: {value: polygons.featureIndex, size: 1},
+      globalFeatureIds: {value: polygons.globalFeatureIds, size: 1},
+      featureIds: {value: polygons.featureIds, size: 1},
       numericProps: polygons.numericProps,
       properties: polygons.properties
     }

--- a/modules/gis/src/lib/geojson-to-binary.js
+++ b/modules/gis/src/lib/geojson-to-binary.js
@@ -20,7 +20,7 @@ function firstPass(features) {
   let polygonRingsCount = 0;
   let polygonFeaturesCount = 0;
   const coordLengths = new Set();
-  const numericProps = {};
+  const numericPropKeys = {};
 
   for (const feature of features) {
     const geometry = feature.geometry;
@@ -88,7 +88,7 @@ function firstPass(features) {
     if (feature.properties) {
       for (const key in feature.properties) {
         const val = feature.properties[key];
-        numericProps[key] = numericProps[key] ? isNumeric(val) : numericProps[key];
+        numericPropKeys[key] = numericPropKeys[key] ? isNumeric(val) : numericPropKeys[key];
       }
     }
   }
@@ -105,7 +105,7 @@ function firstPass(features) {
     polygonRingsCount,
     polygonFeaturesCount,
     // Array of keys whose values are always numeric
-    numericProps: Object.keys(numericProps).filter(k => numericProps[k])
+    numericPropKeys: Object.keys(numericPropKeys).filter(k => numericPropKeys[k])
   };
 }
 
@@ -124,7 +124,7 @@ function secondPass(features, options = {}) {
     polygonObjectsCount,
     polygonRingsCount,
     polygonFeaturesCount,
-    numericProps,
+    numericPropKeys,
     PositionDataType = Float32Array
   } = options;
   const GlobalFeatureIndexDataType = features.length > 65535 ? Uint32Array : Uint16Array;
@@ -173,7 +173,7 @@ function secondPass(features, options = {}) {
 
   // Instantiate numeric properties arrays; one value per vertex
   for (const object of [points, lines, polygons]) {
-    for (const propName of numericProps) {
+    for (const propName of numericPropKeys) {
       object.numericProps[propName] = new Float32Array(object.positions.length / coordLength);
     }
   }

--- a/modules/gis/src/lib/geojson-to-binary.js
+++ b/modules/gis/src/lib/geojson-to-binary.js
@@ -8,6 +8,10 @@ export function geojsonToBinary(features, options = {}) {
   });
 }
 
+export const TEST_EXPORTS = {
+  firstPass
+};
+
 // Initial scan over GeoJSON features
 // Counts number of coordinates of each geometry type and keeps track of the max coordinate
 // dimensions

--- a/modules/gis/src/lib/geojson-to-binary.js
+++ b/modules/gis/src/lib/geojson-to-binary.js
@@ -142,6 +142,7 @@ function secondPass(features, options = {}) {
       object.numericProps[propName] = new Float32Array(object.positions.length / coordLength);
     }
   }
+
   // Set last element of path/polygon indices as positions length
   lines.pathIndices[linePaths] = linePositions;
   polygons.polygonIndices[polygonObjects] = polygonPositions;
@@ -203,23 +204,7 @@ function secondPass(features, options = {}) {
   }
 
   // Wrap each array in an accessor object with value and size keys
-  return {
-    points: {
-      positions: {value: points.positions, size: coordLength},
-      globalFeatureIndex: {value: points.globalFeatureIndex, size: 1}
-    },
-    lines: {
-      pathIndices: {value: lines.pathIndices, size: 1},
-      positions: {value: lines.positions, size: coordLength},
-      globalFeatureIndex: {value: lines.globalFeatureIndex, size: 1}
-    },
-    polygons: {
-      polygonIndices: {value: polygons.polygonIndices, size: 1},
-      primitivePolygonIndices: {value: polygons.primitivePolygonIndices, size: 1},
-      positions: {value: polygons.positions, size: coordLength},
-      globalFeatureIndex: {value: polygons.globalFeatureIndex, size: 1}
-    }
-  };
+  return makeAccessorObjects(points, lines, polygons, coordLength);
 }
 
 // Fills Point coordinates into points object of arrays
@@ -298,6 +283,47 @@ function handleMultiPolygon(coords, polygons, indexMap, coordLength, properties)
   for (const polygon of coords) {
     handlePolygon(polygon, polygons, indexMap, coordLength, properties);
   }
+}
+
+// Wrap each array in an accessor object with value and size keys
+function makeAccessorObjects(points, lines, polygons, coordLength) {
+  const returnObj = {
+    points: {
+      positions: {value: points.positions, size: coordLength},
+      globalFeatureIndex: {value: points.globalFeatureIndex, size: 1},
+      featureIndex: {value: points.featureIndex, size: 1},
+      numericProps: points.numericProps,
+      properties: points.properties
+    },
+    lines: {
+      pathIndices: {value: lines.pathIndices, size: 1},
+      positions: {value: lines.positions, size: coordLength},
+      globalFeatureIndex: {value: lines.globalFeatureIndex, size: 1},
+      featureIndex: {value: lines.featureIndex, size: 1},
+      numericProps: lines.numericProps,
+      properties: lines.properties
+    },
+    polygons: {
+      polygonIndices: {value: polygons.polygonIndices, size: 1},
+      primitivePolygonIndices: {value: polygons.primitivePolygonIndices, size: 1},
+      positions: {value: polygons.positions, size: coordLength},
+      globalFeatureIndex: {value: polygons.globalFeatureIndex, size: 1},
+      featureIndex: {value: polygons.featureIndex, size: 1},
+      numericProps: polygons.numericProps,
+      properties: polygons.properties
+    }
+  };
+
+  // for (const object  [points, lines, polygons]) {
+  for (const geomType in returnObj) {
+    for (const numericProp in returnObj[geomType].numericProps) {
+      returnObj[geomType].numericProps[numericProp] = {
+        value: returnObj[geomType].numericProps[numericProp],
+        size: 1
+      };
+    }
+  }
+  return returnObj;
 }
 
 // Add numeric properties to object

--- a/modules/gis/src/lib/geojson-to-binary.js
+++ b/modules/gis/src/lib/geojson-to-binary.js
@@ -9,7 +9,8 @@ export function geojsonToBinary(features, options = {}) {
 }
 
 export const TEST_EXPORTS = {
-  firstPass
+  firstPass,
+  secondPass
 };
 
 // Initial scan over GeoJSON features

--- a/modules/gis/src/lib/geojson-to-binary.js
+++ b/modules/gis/src/lib/geojson-to-binary.js
@@ -121,16 +121,21 @@ function secondPass(features, firstPassData, options = {}) {
     objectIds: new Uint32Array(pointPositions)
   };
   const lines = {
-    pathIndices: new Uint32Array(linePaths),
+    pathIndices: new Uint32Array(linePaths + 1),
     positions: new PositionDataType(linePositions * coordLength),
     objectIds: new Uint32Array(linePositions)
   };
   const polygons = {
-    polygonIndices: new Uint32Array(polygonObjects),
-    primitivePolygonIndices: new Uint32Array(polygonRings),
+    polygonIndices: new Uint32Array(polygonObjects + 1),
+    primitivePolygonIndices: new Uint32Array(polygonRings + 1),
     positions: new PositionDataType(polygonPositions * coordLength),
     objectIds: new Uint32Array(polygonPositions)
   };
+
+  // Set last element of path/polygon indices as positions length
+  lines.pathIndices[linePaths] = linePositions;
+  polygons.polygonIndices[polygonObjects] = polygonPositions;
+  polygons.primitivePolygonIndices[polygonRings] = polygonPositions;
 
   const indexMap = {
     pointPosition: 0,

--- a/modules/gis/src/lib/geojson-to-binary.js
+++ b/modules/gis/src/lib/geojson-to-binary.js
@@ -113,21 +113,21 @@ function secondPass(features, options = {}) {
   } = options;
   const points = {
     positions: new PositionDataType(pointPositions * coordLength),
-    objectIds: new Uint32Array(pointPositions),
     numericProps: {}
+    globalFeatureIndex: new Uint32Array(pointPositions),
   };
   const lines = {
     pathIndices: new Uint32Array(linePaths + 1),
     positions: new PositionDataType(linePositions * coordLength),
-    objectIds: new Uint32Array(linePositions),
     numericProps: {}
+    globalFeatureIndex: new Uint32Array(linePositions),
   };
   const polygons = {
     polygonIndices: new Uint32Array(polygonObjects + 1),
     primitivePolygonIndices: new Uint32Array(polygonRings + 1),
     positions: new PositionDataType(polygonPositions * coordLength),
-    objectIds: new Uint32Array(polygonPositions),
     numericProps: {}
+    globalFeatureIndex: new Uint32Array(polygonPositions),
   };
 
   // Instantiate numeric properties arrays; one value per vertex
@@ -185,18 +185,18 @@ function secondPass(features, options = {}) {
   return {
     points: {
       positions: {value: points.positions, size: coordLength},
-      objectIds: {value: points.objectIds, size: 1}
+      globalFeatureIndex: {value: points.globalFeatureIndex, size: 1}
     },
     lines: {
       pathIndices: {value: lines.pathIndices, size: 1},
       positions: {value: lines.positions, size: coordLength},
-      objectIds: {value: lines.objectIds, size: 1}
+      globalFeatureIndex: {value: lines.globalFeatureIndex, size: 1}
     },
     polygons: {
       polygonIndices: {value: polygons.polygonIndices, size: 1},
       primitivePolygonIndices: {value: polygons.primitivePolygonIndices, size: 1},
       positions: {value: polygons.positions, size: coordLength},
-      objectIds: {value: polygons.objectIds, size: 1}
+      globalFeatureIndex: {value: polygons.globalFeatureIndex, size: 1}
     }
   };
 }
@@ -204,7 +204,7 @@ function secondPass(features, options = {}) {
 // Fills Point coordinates into points object of arrays
 function handlePoint(coords, points, indexMap, coordLength, properties) {
   points.positions.set(coords, indexMap.pointPosition * coordLength);
-  points.objectIds[indexMap.pointPosition] = indexMap.feature;
+  points.globalFeatureIndex[indexMap.pointPosition] = indexMap.feature;
 
   fillNumericProperties(points, properties, indexMap.pointPosition, 1);
   indexMap.pointPosition++;
@@ -227,7 +227,10 @@ function handleLineString(coords, lines, indexMap, coordLength, properties) {
   const nPositions = coords.length;
   fillNumericProperties(lines, properties, indexMap.linePosition, nPositions);
 
-  lines.objectIds.set(new Uint32Array(nPositions).fill(indexMap.feature), indexMap.linePosition);
+  lines.globalFeatureIndex.set(
+    new Uint32Array(nPositions).fill(indexMap.feature),
+    indexMap.linePosition
+  );
   indexMap.linePosition += nPositions;
 }
 
@@ -252,7 +255,7 @@ function handlePolygon(coords, polygons, indexMap, coordLength, properties) {
     const nPositions = ring.length;
     fillNumericProperties(polygons, properties, indexMap.polygonPosition, nPositions);
 
-    polygons.objectIds.set(
+    polygons.globalFeatureIndex.set(
       new Uint32Array(nPositions).fill(indexMap.feature),
       indexMap.polygonPosition
     );

--- a/modules/gis/src/lib/geojson-to-binary.js
+++ b/modules/gis/src/lib/geojson-to-binary.js
@@ -99,7 +99,8 @@ function firstPass(features) {
     polygonPositions,
     polygonObjects,
     polygonRings,
-    numericProps
+    // Array of keys whose values are always numeric
+    numericProps: Object.keys(numericProps).filter(k => numericProps[k])
   };
 }
 
@@ -113,7 +114,8 @@ function secondPass(features, firstPassData, options = {}) {
     coordLength,
     polygonPositions,
     polygonObjects,
-    polygonRings
+    polygonRings,
+    numericProps
   } = firstPassData;
   const {PositionDataType = Float32Array} = options;
   const points = {
@@ -132,6 +134,12 @@ function secondPass(features, firstPassData, options = {}) {
     objectIds: new Uint32Array(polygonPositions)
   };
 
+  // Instantiate numeric properties arrays; one value per vertex
+  for (const object of [points, lines, polygons]) {
+    for (const propName of numericProps) {
+      object[propName] = new Float32Array(object.positions.length / coordLength);
+    }
+  }
   // Set last element of path/polygon indices as positions length
   lines.pathIndices[linePaths] = linePositions;
   polygons.polygonIndices[polygonObjects] = polygonPositions;

--- a/modules/gis/src/lib/geojson-to-binary.js
+++ b/modules/gis/src/lib/geojson-to-binary.js
@@ -365,7 +365,6 @@ function makeAccessorObjects(points, lines, polygons, coordLength) {
     }
   };
 
-  // for (const object  [points, lines, polygons]) {
   for (const geomType in returnObj) {
     for (const numericProp in returnObj[geomType].numericProps) {
       returnObj[geomType].numericProps[numericProp] = {

--- a/modules/gis/src/lib/geojson-to-binary.js
+++ b/modules/gis/src/lib/geojson-to-binary.js
@@ -1,7 +1,7 @@
 // Convert GeoJSON features to flat binary arrays
 export function geojsonToBinary(features, options = {}) {
   const firstPassData = firstPass(features);
-  return secondPass(features, firstPassData, options);
+  return secondPass(features, {...firstPassData, ...options});
 }
 
 // Initial scan over GeoJSON features
@@ -99,7 +99,7 @@ function firstPass(features) {
 
 // Second scan over GeoJSON features
 // Fills coordinates into pre-allocated typed arrays
-function secondPass(features, firstPassData, options = {}) {
+function secondPass(features, options = {}) {
   const {
     pointPositions,
     linePositions,
@@ -108,9 +108,9 @@ function secondPass(features, firstPassData, options = {}) {
     polygonPositions,
     polygonObjects,
     polygonRings,
-    numericProps
-  } = firstPassData;
-  const {PositionDataType = Float32Array} = options;
+    numericProps,
+    PositionDataType = Float32Array
+  } = options;
   const points = {
     positions: new PositionDataType(pointPositions * coordLength),
     objectIds: new Uint32Array(pointPositions),

--- a/modules/gis/src/lib/geojson-to-binary.js
+++ b/modules/gis/src/lib/geojson-to-binary.js
@@ -131,7 +131,7 @@ function secondPass(features, options = {}) {
     primitivePolygonIndices: new Uint32Array(polygonRings + 1),
     positions: new PositionDataType(polygonPositions * coordLength),
     globalFeatureIndex: new Uint32Array(polygonPositions),
-    featureIndex: new Uint32Array(linePositions),
+    featureIndex: new Uint32Array(polygonPositions),
     numericProps: {},
     properties: []
   };

--- a/modules/gis/src/lib/geojson-to-binary.js
+++ b/modules/gis/src/lib/geojson-to-binary.js
@@ -97,7 +97,14 @@ function firstPass(features) {
     if (feature.properties) {
       for (const key in feature.properties) {
         const val = feature.properties[key];
-        numericPropKeys[key] = numericPropKeys[key] ? isNumeric(val) : numericPropKeys[key];
+
+        // If property has not been seen before, or if property has been numeric
+        // in all previous features, check if numeric in this feature
+        // If not numeric, false is stored to prevent rechecking in the future
+        numericPropKeys[key] =
+          numericPropKeys[key] || numericPropKeys[key] === undefined
+            ? isNumeric(val)
+            : numericPropKeys[key];
       }
     }
   }

--- a/modules/gis/src/lib/geojson-to-binary.js
+++ b/modules/gis/src/lib/geojson-to-binary.js
@@ -99,6 +99,7 @@ function firstPass(features) {
 
 // Second scan over GeoJSON features
 // Fills coordinates into pre-allocated typed arrays
+// eslint-disable-next-line complexity
 function secondPass(features, options = {}) {
   const {
     pointPositionsCount,
@@ -111,27 +112,37 @@ function secondPass(features, options = {}) {
     numericProps,
     PositionDataType = Float32Array
   } = options;
+  const FeatureIndexDataType = features.length > 65535 ? Uint32Array : Uint16Array;
   const points = {
     positions: new PositionDataType(pointPositionsCount * coordLength),
-    globalFeatureIndex: new Uint32Array(pointPositionsCount),
-    featureIndex: new Uint32Array(pointPositionsCount),
+    globalFeatureIndex: new FeatureIndexDataType(pointPositionsCount),
+    featureIndex: new FeatureIndexDataType(pointPositionsCount),
     numericProps: {},
     properties: []
   };
   const lines = {
-    pathIndices: new Uint32Array(linePathsCount + 1),
+    pathIndices:
+      linePositionsCount > 65535
+        ? new Uint32Array(linePathsCount + 1)
+        : new Uint16Array(linePathsCount + 1),
     positions: new PositionDataType(linePositionsCount * coordLength),
-    globalFeatureIndex: new Uint32Array(linePositionsCount),
-    featureIndex: new Uint32Array(linePositionsCount),
+    globalFeatureIndex: new FeatureIndexDataType(linePositionsCount),
+    featureIndex: new FeatureIndexDataType(linePositionsCount),
     numericProps: {},
     properties: []
   };
   const polygons = {
-    polygonIndices: new Uint32Array(polygonObjectsCount + 1),
-    primitivePolygonIndices: new Uint32Array(polygonRingsCount + 1),
+    polygonIndices:
+      polygonPositionsCount > 65535
+        ? new Uint32Array(polygonObjectsCount + 1)
+        : new Uint16Array(polygonObjectsCount + 1),
+    primitivePolygonIndices:
+      polygonPositionsCount > 65535
+        ? new Uint32Array(polygonRingsCount + 1)
+        : new Uint16Array(polygonRingsCount + 1),
     positions: new PositionDataType(polygonPositionsCount * coordLength),
-    globalFeatureIndex: new Uint32Array(polygonPositionsCount),
-    featureIndex: new Uint32Array(polygonPositionsCount),
+    globalFeatureIndex: new FeatureIndexDataType(polygonPositionsCount),
+    featureIndex: new FeatureIndexDataType(polygonPositionsCount),
     numericProps: {},
     properties: []
   };

--- a/modules/gis/src/lib/geojson-to-binary.js
+++ b/modules/gis/src/lib/geojson-to-binary.js
@@ -7,7 +7,7 @@ export function geojsonToBinary(features, options = {}) {
 // Initial scan over GeoJSON features
 // Counts number of coordinates of each geometry type and keeps track of the max coordinate
 // dimensions
-// eslint-disable-next-line complexity
+// eslint-disable-next-line complexity, max-statements
 function firstPass(features) {
   // Counts the number of _positions_, so [x, y, z] counts as one
   let pointPositions = 0;
@@ -17,6 +17,7 @@ function firstPass(features) {
   let polygonObjects = 0;
   let polygonRings = 0;
   let maxCoordLength = 2;
+  const numericProps = {};
 
   for (const feature of features) {
     const geometry = feature.geometry;
@@ -81,6 +82,13 @@ function firstPass(features) {
       default:
         throw new Error(`Unsupported geometry type: ${geometry.type}`);
     }
+
+    if (feature.properties) {
+      for (const key in feature.properties) {
+        const val = feature.properties[key];
+        numericProps[key] = numericProps[key] ? isNumeric(val) : numericProps[key];
+      }
+    }
   }
 
   return {
@@ -90,7 +98,8 @@ function firstPass(features) {
     coordLength: maxCoordLength,
     polygonPositions,
     polygonObjects,
-    polygonRings
+    polygonRings,
+    numericProps
   };
 }
 
@@ -244,4 +253,8 @@ function handleMultiPolygon(coords, polygons, indexMap, coordLength) {
 
 function flatten(arrays) {
   return [].concat(...arrays);
+}
+
+function isNumeric(x) {
+  return Number.isFinite(x);
 }

--- a/modules/gis/src/lib/geojson-to-binary.js
+++ b/modules/gis/src/lib/geojson-to-binary.js
@@ -114,6 +114,7 @@ function secondPass(features, options = {}) {
   const points = {
     positions: new PositionDataType(pointPositions * coordLength),
     globalFeatureIndex: new Uint32Array(pointPositions),
+    featureIndex: new Uint32Array(pointPositions),
     numericProps: {},
     properties: []
   };
@@ -121,6 +122,7 @@ function secondPass(features, options = {}) {
     pathIndices: new Uint32Array(linePaths + 1),
     positions: new PositionDataType(linePositions * coordLength),
     globalFeatureIndex: new Uint32Array(linePositions),
+    featureIndex: new Uint32Array(linePositions),
     numericProps: {},
     properties: []
   };
@@ -129,6 +131,7 @@ function secondPass(features, options = {}) {
     primitivePolygonIndices: new Uint32Array(polygonRings + 1),
     positions: new PositionDataType(polygonPositions * coordLength),
     globalFeatureIndex: new Uint32Array(polygonPositions),
+    featureIndex: new Uint32Array(linePositions),
     numericProps: {},
     properties: []
   };

--- a/modules/gis/src/lib/geojson-to-binary.js
+++ b/modules/gis/src/lib/geojson-to-binary.js
@@ -241,7 +241,7 @@ function handleLineString(coords, lines, indexMap, coordLength, properties) {
   lines.pathIndices[indexMap.linePath] = indexMap.linePosition;
   indexMap.linePath++;
 
-  lines.positions.set(flatten(coords), indexMap.linePosition * coordLength);
+  fillCoords(lines.positions, coords, indexMap.linePosition, coordLength);
 
   const nPositions = coords.length;
   fillNumericProperties(lines, properties, indexMap.linePosition, nPositions);
@@ -273,7 +273,7 @@ function handlePolygon(coords, polygons, indexMap, coordLength, properties) {
     polygons.primitivePolygonIndices[indexMap.polygonRing] = indexMap.polygonPosition;
     indexMap.polygonRing++;
 
-    polygons.positions.set(flatten(ring), indexMap.polygonPosition * coordLength);
+    fillCoords(polygons.positions, ring, indexMap.polygonPosition, coordLength);
 
     const nPositions = ring.length;
     fillNumericProperties(polygons, properties, indexMap.polygonPosition, nPositions);
@@ -318,6 +318,15 @@ function keepStringProperties(properties, numericKeys) {
     }
   }
   return properties;
+}
+
+// coords is expected to be a list of arrays, each with length 2-3
+function fillCoords(array, coords, startVertex, coordLength) {
+  let index = startVertex * coordLength;
+  for (const coord of coords) {
+    array.set(coord, index);
+    index += coordLength;
+  }
 }
 
 function flatten(arrays) {

--- a/modules/gis/src/lib/geojson-to-binary.js
+++ b/modules/gis/src/lib/geojson-to-binary.js
@@ -207,32 +207,32 @@ function secondPass(features, firstPassData = {}, options = {}) {
     switch (geometry.type) {
       case 'Point':
         handlePoint(geometry.coordinates, points, indexMap, coordLength, properties);
-        points.properties.push(keepStringProperties(properties, numericProps));
+        points.properties.push(keepStringProperties(properties, numericPropKeys));
         indexMap.pointFeature++;
         break;
       case 'MultiPoint':
         handleMultiPoint(geometry.coordinates, points, indexMap, coordLength, properties);
-        points.properties.push(keepStringProperties(properties, numericProps));
+        points.properties.push(keepStringProperties(properties, numericPropKeys));
         indexMap.pointFeature++;
         break;
       case 'LineString':
         handleLineString(geometry.coordinates, lines, indexMap, coordLength, properties);
-        lines.properties.push(keepStringProperties(properties, numericProps));
+        lines.properties.push(keepStringProperties(properties, numericPropKeys));
         indexMap.lineFeature++;
         break;
       case 'MultiLineString':
         handleMultiLineString(geometry.coordinates, lines, indexMap, coordLength, properties);
-        lines.properties.push(keepStringProperties(properties, numericProps));
+        lines.properties.push(keepStringProperties(properties, numericPropKeys));
         indexMap.lineFeature++;
         break;
       case 'Polygon':
         handlePolygon(geometry.coordinates, polygons, indexMap, coordLength, properties);
-        polygons.properties.push(keepStringProperties(properties, numericProps));
+        polygons.properties.push(keepStringProperties(properties, numericPropKeys));
         indexMap.polygonFeature++;
         break;
       case 'MultiPolygon':
         handleMultiPolygon(geometry.coordinates, polygons, indexMap, coordLength, properties);
-        polygons.properties.push(keepStringProperties(properties, numericProps));
+        polygons.properties.push(keepStringProperties(properties, numericPropKeys));
         indexMap.polygonFeature++;
         break;
       default:

--- a/modules/gis/test/data/mixed_features.json
+++ b/modules/gis/test/data/mixed_features.json
@@ -1,0 +1,70 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [100.0, 0.0, 1]
+      },
+      "properties": {}
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "MultiPoint",
+        "coordinates": [[100.0, 0.0], [101.0, 1.0]]
+      },
+      "properties": {}
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [[100.0, 0.0], [101.0, 1.0]]
+      },
+      "properties": {}
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "MultiLineString",
+        "coordinates": [[[100.0, 0.0, 2], [101.0, 1.0]], [[102.0, 2.0], [103.0, 3.0]]]
+      },
+      "properties": {}
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [[[100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0, 3]]]
+      },
+      "properties": {}
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [[100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0]],
+          [[100.8, 0.8], [100.8, 0.2], [100.2, 0.2], [100.2, 0.8], [100.8, 0.8]]
+        ]
+      },
+      "properties": {}
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "MultiPolygon",
+        "coordinates": [
+          [[[102.0, 2.0], [103.0, 2.0], [103.0, 3.0], [102.0, 3.0], [102.0, 2.0]]],
+          [
+            [[100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0]],
+            [[100.2, 0.2], [100.2, 0.8], [100.8, 0.8], [100.8, 0.2], [100.2, 0.2]]
+          ]
+        ]
+      },
+      "properties": {}
+    }
+  ]
+}

--- a/modules/gis/test/geojson-to-binary.spec.js
+++ b/modules/gis/test/geojson-to-binary.spec.js
@@ -107,6 +107,41 @@ test('gis#geojson-to-binary firstPass mixed-dimension features, no properties', 
   t.equal(polygonFeaturesCount, 3);
   t.equal(coordLength, 3);
   t.deepEquals(numericPropKeys, []);
+
+  const options = {
+    coordLength: firstPassData.coordLength,
+    numericPropKeys: firstPassData.numericPropKeys,
+    PositionDataType: Float32Array
+  };
+  const {points, lines, polygons} = secondPass(features, firstPassData, options);
+
+  // 3D size
+  t.equal(points.positions.size, 3);
+  t.equal(lines.positions.size, 3);
+  t.equal(polygons.positions.size, 3);
+
+  // Test value equality, missing third dimension imputed as 0
+  t.deepEqual(points.positions.value, [100, 0, 1, 100, 0, 0, 101, 1, 0]);
+  t.deepEqual(lines.positions.value, [
+    100,
+    0,
+    0,
+    101,
+    1,
+    0,
+    100,
+    0,
+    2,
+    101,
+    1,
+    0,
+    102,
+    2,
+    0,
+    103,
+    3,
+    0
+  ]);
   t.end();
 });
 

--- a/modules/gis/test/geojson-to-binary.spec.js
+++ b/modules/gis/test/geojson-to-binary.spec.js
@@ -1,6 +1,8 @@
 import test from 'tape-promise/tape';
 import {fetchFile} from '@loaders.gl/core';
-import {geojsonToBinary} from '@loaders.gl/gis';
+import {geojsonToBinary, TEST_EXPORTS} from '@loaders.gl/gis';
+
+const {firstPass} = TEST_EXPORTS;
 
 // Sample GeoJSON data derived from examples in GeoJSON specification
 // https://tools.ietf.org/html/rfc7946#appendix-A
@@ -8,6 +10,101 @@ import {geojsonToBinary} from '@loaders.gl/gis';
 const FEATURES_2D = '@loaders.gl/gis/test/data/2d_features.json';
 // All features have 3D coordinates
 const FEATURES_3D = '@loaders.gl/gis/test/data/3d_features.json';
+// All features have 3D coordinates
+const FEATURES_MIXED = '@loaders.gl/gis/test/data/mixed_features.json';
+
+test('gis#firstPass 2D features, no properties', async t => {
+  const response = await fetchFile(FEATURES_2D);
+  const {features} = await response.json();
+  const firstPassData = firstPass(features);
+  const {
+    pointPositionsCount,
+    pointFeaturesCount,
+    linePositionsCount,
+    linePathsCount,
+    lineFeaturesCount,
+    polygonPositionsCount,
+    polygonObjectsCount,
+    polygonRingsCount,
+    polygonFeaturesCount,
+    coordLength,
+    numericPropKeys
+  } = firstPassData;
+
+  t.equal(pointPositionsCount, 3);
+  t.equal(pointFeaturesCount, 2);
+  t.equal(linePositionsCount, 6);
+  t.equal(linePathsCount, 3);
+  t.equal(lineFeaturesCount, 2);
+  t.equal(polygonPositionsCount, 30);
+  t.equal(polygonObjectsCount, 4);
+  t.equal(polygonRingsCount, 6);
+  t.equal(polygonFeaturesCount, 3);
+  t.equal(coordLength, 2);
+  t.deepEquals(numericPropKeys, []);
+});
+
+test('gis#firstPass 3D features, no properties', async t => {
+  const response = await fetchFile(FEATURES_3D);
+  const {features} = await response.json();
+  const firstPassData = firstPass(features);
+  const {
+    pointPositionsCount,
+    pointFeaturesCount,
+    linePositionsCount,
+    linePathsCount,
+    lineFeaturesCount,
+    polygonPositionsCount,
+    polygonObjectsCount,
+    polygonRingsCount,
+    polygonFeaturesCount,
+    coordLength,
+    numericPropKeys
+  } = firstPassData;
+
+  t.equal(pointPositionsCount, 3);
+  t.equal(pointFeaturesCount, 2);
+  t.equal(linePositionsCount, 6);
+  t.equal(linePathsCount, 3);
+  t.equal(lineFeaturesCount, 2);
+  t.equal(polygonPositionsCount, 30);
+  t.equal(polygonObjectsCount, 4);
+  t.equal(polygonRingsCount, 6);
+  t.equal(polygonFeaturesCount, 3);
+  t.equal(coordLength, 3);
+  t.deepEquals(numericPropKeys, []);
+});
+
+test('gis#firstPass mixed-dimension features, no properties', async t => {
+  const response = await fetchFile(FEATURES_MIXED);
+  const {features} = await response.json();
+  const firstPassData = firstPass(features);
+  const {
+    pointPositionsCount,
+    pointFeaturesCount,
+    linePositionsCount,
+    linePathsCount,
+    lineFeaturesCount,
+    polygonPositionsCount,
+    polygonObjectsCount,
+    polygonRingsCount,
+    polygonFeaturesCount,
+    coordLength,
+    numericPropKeys
+  } = firstPassData;
+
+  t.equal(pointPositionsCount, 3);
+  t.equal(pointFeaturesCount, 2);
+  t.equal(linePositionsCount, 6);
+  t.equal(linePathsCount, 3);
+  t.equal(lineFeaturesCount, 2);
+  t.equal(polygonPositionsCount, 30);
+  t.equal(polygonObjectsCount, 4);
+  t.equal(polygonRingsCount, 6);
+  t.equal(polygonFeaturesCount, 3);
+  t.equal(coordLength, 3);
+  t.deepEquals(numericPropKeys, []);
+});
 
 test('gis#geojson-to-binary 2D features', async t => {
   const response = await fetchFile(FEATURES_2D);

--- a/modules/gis/test/geojson-to-binary.spec.js
+++ b/modules/gis/test/geojson-to-binary.spec.js
@@ -110,6 +110,63 @@ test('gis#firstPass mixed-dimension features, no properties', async t => {
   t.end();
 });
 
+test('gis#firstPass numeric properties', async t => {
+  const response = await fetchFile(FEATURES_2D);
+  const {features} = await response.json();
+
+  // Add properties to features
+  // Uniform string, missing in some features
+  features[0].properties.string1 = 'string';
+  features[1].properties.string1 = 'string';
+
+  // Uniform string, in all features
+  for (const feature of features) {
+    feature.properties.string2 = 'string';
+  }
+
+  // Mixed string/numeric, missing in some features
+  features[0].properties.mixed1 = 'mixed';
+  features[1].properties.mixed1 = 1;
+
+  // Mixed string/numeric, in all features
+  for (const feature of features) {
+    feature.properties.mixed2 = 'string';
+  }
+  features[0].properties.mixed2 = 1;
+
+  // Uniform integer, missing in some features
+  features[0].properties.int1 = 0;
+  features[1].properties.int1 = 1;
+
+  // Uniform integer, in all features
+  for (const feature of features) {
+    feature.properties.int2 = 1;
+  }
+
+  // Uniform float, missing in some features
+  features[0].properties.float1 = 3.14;
+  features[1].properties.float1 = 2.14;
+
+  // Uniform float, in all features
+  for (const feature of features) {
+    feature.properties.float2 = 3.14;
+  }
+
+  // Mixed int/float, missing in some features
+  features[0].properties.numeric1 = 1;
+  features[1].properties.numeric1 = 2.14;
+
+  // Mixed int/float, in all features
+  for (const feature of features) {
+    feature.properties.numeric2 = 3.14;
+  }
+  features[0].properties.numeric2 = 1;
+
+  const {numericPropKeys} = firstPass(features);
+  t.deepEquals(numericPropKeys, ['int1', 'int2', 'float1', 'float2', 'numeric1', 'numeric2']);
+  t.end();
+});
+
 test('gis#secondPass 2D features, no properties', async t => {
   const response = await fetchFile(FEATURES_2D);
   const {features} = await response.json();

--- a/modules/gis/test/geojson-to-binary.spec.js
+++ b/modules/gis/test/geojson-to-binary.spec.js
@@ -20,24 +20,24 @@ test('gis#geojson-to-binary 2D features', async t => {
   t.equal(polygons.positions.size, 2);
 
   // Other arrays have coordinate size 1
-  t.equal(points.globalFeatureIndex.size, 1);
-  t.equal(points.featureIndex.size, 1);
+  t.equal(points.globalFeatureIds.size, 1);
+  t.equal(points.featureIds.size, 1);
   t.equal(lines.pathIndices.size, 1);
-  t.equal(lines.globalFeatureIndex.size, 1);
-  t.equal(lines.featureIndex.size, 1);
+  t.equal(lines.globalFeatureIds.size, 1);
+  t.equal(lines.featureIds.size, 1);
   t.equal(polygons.polygonIndices.size, 1);
   t.equal(polygons.primitivePolygonIndices.size, 1);
-  t.equal(polygons.globalFeatureIndex.size, 1);
-  t.equal(polygons.featureIndex.size, 1);
+  t.equal(polygons.globalFeatureIds.size, 1);
+  t.equal(polygons.featureIds.size, 1);
 
   // Point value equality
   t.deepEqual(points.positions.value, [100, 0, 100, 0, 101, 1]);
-  t.deepEqual(points.globalFeatureIndex.value, [0, 1, 1]);
+  t.deepEqual(points.globalFeatureIds.value, [0, 1, 1]);
 
   // LineString value equality
   t.deepEqual(lines.pathIndices.value, [0, 2, 4, 6]);
   t.deepEqual(lines.positions.value, [100, 0, 101, 1, 100, 0, 101, 1, 102, 2, 103, 3]);
-  t.deepEqual(lines.globalFeatureIndex.value, [2, 2, 3, 3, 3, 3]);
+  t.deepEqual(lines.globalFeatureIds.value, [2, 2, 3, 3, 3, 3]);
 
   // Polygon value equality
   t.deepEqual(polygons.polygonIndices.value, [0, 5, 15, 20, 30]);
@@ -107,7 +107,7 @@ test('gis#geojson-to-binary 2D features', async t => {
       0.2
     ])
   );
-  t.deepEqual(polygons.globalFeatureIndex.value, [
+  t.deepEqual(polygons.globalFeatureIds.value, [
     4,
     4,
     4,
@@ -153,19 +153,19 @@ test('gis#geojson-to-binary 3D features', async t => {
   t.equal(polygons.positions.size, 3);
 
   // Other arrays have coordinate size 1
-  t.equal(points.globalFeatureIndex.size, 1);
-  t.equal(points.featureIndex.size, 1);
+  t.equal(points.globalFeatureIds.size, 1);
+  t.equal(points.featureIds.size, 1);
   t.equal(lines.pathIndices.size, 1);
-  t.equal(lines.globalFeatureIndex.size, 1);
-  t.equal(lines.featureIndex.size, 1);
+  t.equal(lines.globalFeatureIds.size, 1);
+  t.equal(lines.featureIds.size, 1);
   t.equal(polygons.polygonIndices.size, 1);
   t.equal(polygons.primitivePolygonIndices.size, 1);
-  t.equal(polygons.globalFeatureIndex.size, 1);
-  t.equal(polygons.featureIndex.size, 1);
+  t.equal(polygons.globalFeatureIds.size, 1);
+  t.equal(polygons.featureIds.size, 1);
 
   // Point value equality
   t.deepEqual(points.positions.value, [100, 0, 1, 100, 0, 2, 101, 1, 3]);
-  t.deepEqual(points.globalFeatureIndex.value, [0, 1, 1]);
+  t.deepEqual(points.globalFeatureIds.value, [0, 1, 1]);
 
   // LineString value equality
   t.deepEqual(lines.pathIndices.value, [0, 2, 4, 6]);
@@ -189,7 +189,7 @@ test('gis#geojson-to-binary 3D features', async t => {
     3,
     9
   ]);
-  t.deepEqual(lines.globalFeatureIndex.value, [2, 2, 3, 3, 3, 3]);
+  t.deepEqual(lines.globalFeatureIds.value, [2, 2, 3, 3, 3, 3]);
 
   // Polygon value equality
   t.deepEqual(polygons.polygonIndices.value, [0, 5, 15, 20, 30]);

--- a/modules/gis/test/geojson-to-binary.spec.js
+++ b/modules/gis/test/geojson-to-binary.spec.js
@@ -32,13 +32,13 @@ test('gis#geojson-to-binary 2D features', async t => {
   t.deepEqual(points.objectIds.value, [0, 1, 1]);
 
   // LineString value equality
-  t.deepEqual(lines.pathIndices.value, [0, 2, 4]);
+  t.deepEqual(lines.pathIndices.value, [0, 2, 4, 6]);
   t.deepEqual(lines.positions.value, [100, 0, 101, 1, 100, 0, 101, 1, 102, 2, 103, 3]);
   t.deepEqual(lines.objectIds.value, [2, 2, 3, 3, 3, 3]);
 
   // Polygon value equality
-  t.deepEqual(polygons.polygonIndices.value, [0, 5, 15, 20]);
-  t.deepEqual(polygons.primitivePolygonIndices.value, [0, 5, 10, 15, 20, 25]);
+  t.deepEqual(polygons.polygonIndices.value, [0, 5, 15, 20, 30]);
+  t.deepEqual(polygons.primitivePolygonIndices.value, [0, 5, 10, 15, 20, 25, 30]);
   t.deepEqual(
     polygons.positions.value,
     Float32Array.from([
@@ -162,7 +162,7 @@ test('gis#geojson-to-binary 3D features', async t => {
   t.deepEqual(points.objectIds.value, [0, 1, 1]);
 
   // LineString value equality
-  t.deepEqual(lines.pathIndices.value, [0, 2, 4]);
+  t.deepEqual(lines.pathIndices.value, [0, 2, 4, 6]);
   t.deepEqual(lines.positions.value, [
     100,
     0,
@@ -186,8 +186,8 @@ test('gis#geojson-to-binary 3D features', async t => {
   t.deepEqual(lines.objectIds.value, [2, 2, 3, 3, 3, 3]);
 
   // Polygon value equality
-  t.deepEqual(polygons.polygonIndices.value, [0, 5, 15, 20]);
-  t.deepEqual(polygons.primitivePolygonIndices.value, [0, 5, 10, 15, 20, 25]);
+  t.deepEqual(polygons.polygonIndices.value, [0, 5, 15, 20, 30]);
+  t.deepEqual(polygons.primitivePolygonIndices.value, [0, 5, 10, 15, 20, 25, 30]);
   t.deepEqual(
     polygons.positions.value,
     Float32Array.from([

--- a/modules/gis/test/geojson-to-binary.spec.js
+++ b/modules/gis/test/geojson-to-binary.spec.js
@@ -20,21 +20,24 @@ test('gis#geojson-to-binary 2D features', async t => {
   t.equal(polygons.positions.size, 2);
 
   // Other arrays have coordinate size 1
-  t.equal(points.objectIds.size, 1);
+  t.equal(points.globalFeatureIndex.size, 1);
+  t.equal(points.featureIndex.size, 1);
   t.equal(lines.pathIndices.size, 1);
-  t.equal(lines.objectIds.size, 1);
+  t.equal(lines.globalFeatureIndex.size, 1);
+  t.equal(lines.featureIndex.size, 1);
   t.equal(polygons.polygonIndices.size, 1);
   t.equal(polygons.primitivePolygonIndices.size, 1);
-  t.equal(polygons.objectIds.size, 1);
+  t.equal(polygons.globalFeatureIndex.size, 1);
+  t.equal(polygons.featureIndex.size, 1);
 
   // Point value equality
   t.deepEqual(points.positions.value, [100, 0, 100, 0, 101, 1]);
-  t.deepEqual(points.objectIds.value, [0, 1, 1]);
+  t.deepEqual(points.globalFeatureIndex.value, [0, 1, 1]);
 
   // LineString value equality
   t.deepEqual(lines.pathIndices.value, [0, 2, 4, 6]);
   t.deepEqual(lines.positions.value, [100, 0, 101, 1, 100, 0, 101, 1, 102, 2, 103, 3]);
-  t.deepEqual(lines.objectIds.value, [2, 2, 3, 3, 3, 3]);
+  t.deepEqual(lines.globalFeatureIndex.value, [2, 2, 3, 3, 3, 3]);
 
   // Polygon value equality
   t.deepEqual(polygons.polygonIndices.value, [0, 5, 15, 20, 30]);
@@ -104,7 +107,7 @@ test('gis#geojson-to-binary 2D features', async t => {
       0.2
     ])
   );
-  t.deepEqual(polygons.objectIds.value, [
+  t.deepEqual(polygons.globalFeatureIndex.value, [
     4,
     4,
     4,
@@ -150,16 +153,19 @@ test('gis#geojson-to-binary 3D features', async t => {
   t.equal(polygons.positions.size, 3);
 
   // Other arrays have coordinate size 1
-  t.equal(points.objectIds.size, 1);
+  t.equal(points.globalFeatureIndex.size, 1);
+  t.equal(points.featureIndex.size, 1);
   t.equal(lines.pathIndices.size, 1);
-  t.equal(lines.objectIds.size, 1);
+  t.equal(lines.globalFeatureIndex.size, 1);
+  t.equal(lines.featureIndex.size, 1);
   t.equal(polygons.polygonIndices.size, 1);
   t.equal(polygons.primitivePolygonIndices.size, 1);
-  t.equal(polygons.objectIds.size, 1);
+  t.equal(polygons.globalFeatureIndex.size, 1);
+  t.equal(polygons.featureIndex.size, 1);
 
   // Point value equality
   t.deepEqual(points.positions.value, [100, 0, 1, 100, 0, 2, 101, 1, 3]);
-  t.deepEqual(points.objectIds.value, [0, 1, 1]);
+  t.deepEqual(points.globalFeatureIndex.value, [0, 1, 1]);
 
   // LineString value equality
   t.deepEqual(lines.pathIndices.value, [0, 2, 4, 6]);
@@ -183,7 +189,7 @@ test('gis#geojson-to-binary 3D features', async t => {
     3,
     9
   ]);
-  t.deepEqual(lines.objectIds.value, [2, 2, 3, 3, 3, 3]);
+  t.deepEqual(lines.globalFeatureIndex.value, [2, 2, 3, 3, 3, 3]);
 
   // Polygon value equality
   t.deepEqual(polygons.polygonIndices.value, [0, 5, 15, 20, 30]);


### PR DESCRIPTION
@ibgreen 

- [x] Index array length fixed, where the last value is coordinate length
- [x] Mixed coordinate dimensions: Should be fixed; if mixed coordinate lengths, `0` is left for the missing values
- [x] Numeric properties added to typed arrays, where each property is contained within the `points/lines/polygons.numericProps` object. It was helpful to make it its own object, since I loop over the keys of `numericProps` a couple times.
- [x] Calculations from the first pass are combined with user-provided options. So, for example, if a user didn't want any numeric properties in binary arrays, they could pass `numericProps = []`.
- [x] Feature properties (minus any numeric keys) are added to `properties` arrays by geometry type. If the user passes `numericProps = []`, all properties are kept as JSON.
- [x] Both `featureIndex` and `globalFeatureIndex` arrays are created.
- [x] Add new tests/fix changes to existing tests
- [x] Use smallest data type necessary for TypedArrays
- [ ] An option for user-defined missing values for `positions` and numeric feature properties? I.e. if non-zero, fill this as the default value for `positions` when it's initialized, and then I think the third coordinate won't get overwritten when filling a 2D point.

Closes #702 